### PR TITLE
fix(content): replace unapproved homepage claims

### DIFF
--- a/www/src/pages/index.astro
+++ b/www/src/pages/index.astro
@@ -18,13 +18,9 @@ import BaseLayout from "../layouts/BaseLayout.astro";
     <section class="hero" aria-labelledby="hero-heading">
       <div class="hero__inner">
         <h1 id="hero-heading" class="hero__title">
-          Technology consulting<br />
-          <span class="hero__title-accent">built for what comes next.</span>
+          <span class="hero__title-accent">Jamula</span>
         </h1>
-        <p class="hero__lead">
-          Jamula helps organisations design, build, and operate modern software systems. More to
-          come.
-        </p>
+        <p class="hero__lead">More to come.</p>
       </div>
     </section>
   </div>


### PR DESCRIPTION
## Summary

Replaces the two unapproved homepage service claims introduced by PR #16 with neutral placeholder copy. This is an independent editorial revision by Nyota Uhura following Fact Checker's **CHANGES REQUIRED** verdict; original author Geordi La Forge did not advise, co-author, or modify this revision.

Closes #20

## Exact change

- Hero heading: `Jamula`
- Hero lead: `More to come.`
- Preserves existing styles, metadata, semantic heading linkage, and the approved `Jamula, Inc.` footer.

## Scope

Only `www/src/pages/index.astro` changed. No dependencies, workflows, Azure, DNS, documentation, Squad state, or footer changes.

## Evidence

Base SHA: `2fd441457b91020988e9799cc69d26de371f276c` (PR #16 merge commit)

Revision SHA: `93ed19a2148fcdd791e597bd79bdea81faf55f45`

- `npx prettier --check src/pages/index.astro`: passed
- `npx astro check`: 7 files, 0 errors, 0 warnings, 0 hints
- `npx astro build`: 2 pages built successfully; sitemap generated
- Generated `dist/index.html`: rejected claim strings absent
- Generated `dist/index.html`: exactly one `<h1>`, retaining `id="hero-heading"`
- Hero `<section>` retains `aria-labelledby="hero-heading"`
- Generated heading contains `Jamula`; lead contains `More to come.`

## Review gate

Do not merge until Fact Checker re-verifies this exact revision SHA. Any new commit invalidates that review.