### PR TITLE
[Squad] feat(www): enforce strict npm lifecycle-script allow-list

### DIFF
--- a/www/.npmrc
+++ b/www/.npmrc
@@ -4,3 +4,10 @@
 # integrity entries in the lockfile.  The machine-local Microsoft proxy
 # registry is intentionally bypassed; no credentials are required or stored.
 registry=https://registry.npmjs.org/
+
+# Enforce the allowScripts allow-list as a hard error rather than a warning.
+# Any dependency whose lifecycle scripts are not covered by the allowScripts
+# field in package.json will cause the install to fail rather than being
+# silently skipped.  Documented and empirically verified with npm 12.0.2.
+# See: npm help config (strict-allow-scripts) and npm install-scripts docs.
+strict-allow-scripts=true

--- a/www/package.json
+++ b/www/package.json
@@ -3,6 +3,10 @@
   "type": "module",
   "version": "0.1.0",
   "private": true,
+  "engines": {
+    "node": ">=22.12.0",
+    "npm": ">=12.0.0"
+  },
   "scripts": {
     "dev": "astro dev",
     "build": "astro check && astro build",


### PR DESCRIPTION
## Summary

Seven of Nine (Identity, Data & AI Engineer) — implementation of issue #24 under the Reviewer Rejection Protocol. Geordi La Forge, the GitHub Copilot coding agent, and Miles O'Brien are locked out of this package-policy artifact revision cycle; they may not advise, co-author, or modify it. Fact Checker will independently review this result.

Closes #24
Refs #23 (corrects the inaccurate npm 7+ claim from that PR's `allowScripts` evaluation)

---

## Problem

PR #23 successfully eliminated SHA-1 integrity and Microsoft proxy URLs from the lockfile, but its `allowScripts` evaluation contained an error:

> "npm 7+ officially supports `allowScripts` in `package.json` as a per-package lifecycle-script allow-list via `@npmcli/run-script`."

This claim is **not supported by npm 12 first-party docs or source**. The `allowScripts` field as managed by `npm install-scripts approve` / `npm approve-scripts`, and the `strict-allow-scripts` config option, are **npm 12 features** — empirically verified via npm 12.0.2 docs and source. No evidence was found to support the npm 7 claim.

Additionally, without `strict-allow-scripts=true`, unapproved lifecycle scripts are **silently skipped with a warning** (fail-open). The policy needed to be hardened to fail-closed.

---

## Changes

| File | Change |
|------|--------|
| `www/.npmrc` | Added `strict-allow-scripts=true` — turns the allowScripts policy from a warning into a hard error (`ESTRICTALLOWSCRIPTS`) |
| `www/package.json` | Added `engines` field documenting the minimum verified runtime (node ≥ 22.12.0 from Astro 7; npm ≥ 12.0.0 empirically verified for strict-allow-scripts) |

No changes to `www/package-lock.json` — the lockfile records the dependency graph, which was not modified by this policy change.

---

## npm Mechanism — First-Party Evidence

**Source:** npm 12.0.2 installed docs (`$npm_prefix/node_modules/npm/docs/content/`)

### `strict-allow-scripts` (`.npmrc`)

From `npm-ci.md` and `npm-install.md` (npm 12.0.2):

> If `true`, turn the install-script policy from a warning into a hard error: any dependency with install scripts that is not covered by `allowScripts` will fail the install instead of being blocked with a warning.
>
> Dependencies explicitly denied with `false` in `allowScripts` are always silently skipped; this setting only affects unreviewed entries (packages with install scripts that are neither approved nor denied).

Default: `false`. Setting to `true` enforces fail-closed behavior.

### `allowScripts` (`package.json`)

From `npm-approve-scripts.md` and `npm-install-scripts.md` (npm 12.0.2):

> Manages the `allowScripts` field in your project's `package.json`, which records which of your dependencies are permitted to run install scripts (`preinstall`, `install`, `postinstall`, and `prepare` for non-registry sources).
>
> Dependency install scripts are blocked by default. Install commands silently skip lifecycle scripts for any dependency that does not have a matching entry in `allowScripts`.

### Packages with `hasInstallScript: true` in lockfile

| Package | `hasInstallScript` | `allowScripts` entry | Notes |
|---------|---------------------|----------------------|-------|
| `esbuild@0.28.2` | ✅ true | `"esbuild@0.28.2": true` ✅ | Approved — postinstall downloads platform binary |
| `fsevents@2.3.3` | ✅ true | not present | `optional: true`, `os: ["darwin"]` — npm 12 docs: "Optional dependencies that cannot be installed on the current platform…are not flagged, because their install scripts never run." Not flagged on Windows or Linux CI runners. |

---

## Corrected npm Support Statement

| Claim in PR #23 | Correction |
|-----------------|------------|
| "npm 7+ officially supports `allowScripts`" | **Incorrect.** `allowScripts` in `package.json` (managed by `npm install-scripts approve` / `npm approve-scripts`) and `strict-allow-scripts` are documented in npm 12. No first-party evidence found for npm < 12. |
| No `engines` field | **Added.** `node >=22.12.0` (Astro 7 requirement per lockfile engines entry), `npm >=12.0.0` (empirically verified for strict-allow-scripts). |

---

## Runtime Matrix

| Runtime | Verified | Notes |
|---------|----------|-------|
| Node 26.7.0 / npm 12.0.2 / Windows | ✅ Empirically verified | Current dev machine |
| Node ≥22.12.0 / npm ≥12.0.0 / Linux | Expected ✅ | GitHub-hosted CI runners; fsevents skipped (darwin-only) |
| npm < 12.0.0 | ⚠️ Not verified | `strict-allow-scripts` existence in earlier versions not confirmed |

**Limitation:** Only Node 26.7.0 / npm 12.0.2 was installed. Broader runtime proof was not claimed per issue #24 scope.

---

## Negative Test — Unapproved Script Is Blocked

**Setup:** Disposable temp directory outside the repo (`$env:TEMP/npm-policy-neg-test-*`), not committed.

```
www/.npmrc:
  registry=https://registry.npmjs.org/
  strict-allow-scripts=true

package.json (temp):
  { "dependencies": { "esbuild": "0.28.2" } }
  # NO allowScripts entry
```

**Result:**
```
npm error code ESTRICTALLOWSCRIPTS
npm error --strict-allow-scripts: 1 package(s) have install scripts not covered by allowScripts:
npm error   esbuild@0.28.2 (postinstall: node install.js)
Exit code: 1
```

✅ Unapproved lifecycle script fails hard. Temp directory cleaned up.

---

## Positive Test — Approved esbuild Script Succeeds

```
npm ci
# Result: added 273 packages, and audited 274 packages in 9s
# 83 packages are looking for funding
# found 0 vulnerabilities

npm approve-scripts --allow-scripts-pending
# Result: No packages with unreviewed install scripts.
```

✅ Clean install succeeds with `strict-allow-scripts=true` and approved `esbuild@0.28.2`.

---

## Full Validation Evidence

**Environment:** Node 26.7.0 / npm 12.0.2 / Windows

| Check | Result |
|-------|--------|
| `npm ci` | ✅ 273 packages added, 0 vulnerabilities |
| `npm approve-scripts --allow-scripts-pending` | ✅ No packages with unreviewed install scripts |
| `prettier --check package.json` | ✅ All matched files use Prettier code style |
| `astro check` | ✅ 0 errors, 0 warnings, 0 hints (7 files) |
| `astro build` | ✅ 2 pages built, output: static |

**Note on `prettier --check` (full suite):** Format check fails on 12 files. This is the **pre-existing condition on `main`** carried forward from PR #16/PR #23. The files failing are outside this issue's exclusive artifact paths (`www/.npmrc`, `www/package.json`, `www/package-lock.json`). `www/package.json` was formatted with prettier as part of this PR (it was one of the 13 previously-failing files); `www/.npmrc` has no prettier parser. The remaining 12 failures are out of scope for issue #24.

---

## Integrity Counts

| Metric | Count |
|--------|-------|
| SHA-1 integrity entries | **0** |
| SHA-512 integrity entries | **373** |
| Microsoft proxy resolved URLs | **0** |

---

## SHAs

- **Base (origin/main):** `5e8d6c1ce6f74ce31203686ba1949edda0e8a029` (merge commit for PR #23)
- **Head:** `e55751897024ccd3a948ff06b88d75084ee0a0af`

---

## Lockout Context

- **Locked out:** Geordi La Forge, GitHub Copilot coding agent (@copilot), Miles O'Brien
- **Revision owner:** Seven of Nine (Identity, Data & AI Engineer)
- **Fact Checker:** will independently review this revision before merge
- **Do not merge** until Fact Checker completes review and Cyrus approves the exact head SHA

The mandatory Copilot App trailer on the commit is repository attribution policy and does **not** indicate participation by the locked-out GitHub Copilot coding agent.