### PR TITLE
[Squad] Add universal required PR validation gate

### DIFF
--- a/.github/workflows/required-pr-validation.yml
+++ b/.github/workflows/required-pr-validation.yml
@@ -1,0 +1,83 @@
+name: Required PR Validation
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  required-pr-validation:
+    name: required-pr-validation
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: www
+    steps:
+      - name: Check out pull request
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Detect website changes
+        id: changes
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          changed_files="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- ':(top)www/')"
+          if [[ -n "$changed_files" ]]; then
+            echo "website=true" >> "$GITHUB_OUTPUT"
+            echo "Website validation required."
+          else
+            echo "website=false" >> "$GITHUB_OUTPUT"
+            echo "No website changes; npm validation is not required."
+          fi
+
+      - name: Set up Node.js
+        if: steps.changes.outputs.website == 'true'
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: 22.12.0
+          cache: npm
+          cache-dependency-path: www/package-lock.json
+
+      - name: Install npm 12
+        if: steps.changes.outputs.website == 'true'
+        run: npm install --global npm@12.0.2
+
+      - name: Install website dependencies
+        if: steps.changes.outputs.website == 'true'
+        run: npm ci
+
+      - name: Check website formatting
+        if: steps.changes.outputs.website == 'true'
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          git diff --name-only --diff-filter=ACMRT -z "$BASE_SHA" "$HEAD_SHA" -- ':(top)www/' |
+            while IFS= read -r -d '' file; do
+              case "$file" in
+                www/.prettierrc|*.astro|*.css|*.js|*.jsx|*.json|*.md|*.mdx|*.mjs|*.ts|*.tsx|*.yaml|*.yml)
+                  printf './%s\0' "${file#www/}"
+                  ;;
+              esac
+            done |
+            xargs --null --no-run-if-empty npm exec -- prettier --check
+
+      - name: Check Astro project
+        if: steps.changes.outputs.website == 'true'
+        run: npm run check
+
+      - name: Build static website
+        if: steps.changes.outputs.website == 'true'
+        run: npm exec -- astro build


### PR DESCRIPTION
## Summary

Working as Geordi La Forge (Full-Stack & Platform Engineer), add one stable repository-owned `required-pr-validation` job for every pull request targeting `main`.

Closes #26

## Check architecture

- `.github/workflows/required-pr-validation.yml` has no top-level path filter, so the `required-pr-validation` job always reports on PRs to `main`.
- The job detects `www/` changes from the immutable pull-request base/head SHAs after a full read-only checkout.
- Required website steps are direct steps in the same job; install, format, Astro check, or static-build failures fail the stable context.
- Concurrency is scoped to workflow + PR number and cancels superseded runs.

## Runtime and path behavior

- Website validation pins Node `22.12.0` and explicitly installs npm `12.0.2` (npm 12.x, not an unbounded latest major), matching the policy merged in PR #27.
- `actions/setup-node` uses the `www/package-lock.json` npm cache.
- Website changes run `npm ci`, Prettier against changed supported files only, `astro check`, and `astro build` from `www/`.
- PRs without `www/` changes skip npm work while the same required job remains successful.

## Permissions and fork safety

- Workflow permissions are limited to `contents: read`.
- Checkout credentials are not persisted.
- Detection uses local Git history and pull-request payload SHAs; it does not execute API calls or require secrets/Azure credentials.

## Evidence

- Base SHA: `2210f60fd347ea8bfb104af04671b2742ad5e996` (`origin/main`, includes merged PR #27).
- Head SHA: `1897d9cd63d58399a34f5c774e153ba6b90d3464`.
- Workflow YAML parsed locally, both changed/unchanged path branches were exercised, `npm ci` completed under npm `12.0.2`, and the Astro check/static build completed from `www/`.
- GitHub check `required-pr-validation` completed successfully in 6 seconds for this non-website PR and explicitly skipped Node/npm work: https://github.com/Jamula/Jamula-www-Website/actions/runs/33233792752/job/99051104761
- All draft PR checks completed successfully; the PR remains draft and mergeable without conflicts.

## Rollback

Revert this PR (or remove `.github/workflows/required-pr-validation.yml`) to remove the universal gate. This PR does not change branch protection; any later required-context configuration must be rolled back separately by removing the exact `required-pr-validation` context.