### PR TITLE
[Squad] feat(infra): Azure Static Web Apps deployment — Closes #15

### DIFF
--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -49,16 +49,13 @@ permissions:
   contents: read
 
 concurrency:
-  # PRs share a group keyed by PR number; a new push to the PR branch cancels
-  # the prior in-progress run. Push-to-main and PR-close events use the unique
-  # run_id so they are never cancelled.
-  group: >-
-    swa-${{
-      github.event_name == 'pull_request' && github.event.action != 'closed'
-        && github.event.pull_request.number
-        || github.run_id
-    }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action != 'closed' }}
+  # Production deploys share one group and are never cancelled, ensuring pushes
+  # to main complete in queue order so a faster later run cannot overwrite a
+  # slower earlier one and restore stale content. Each PR (including its
+  # 'closed' event) uses a per-PR group so a new push cancels the prior preview
+  # and the close event cancels any in-progress preview upload before cleanup.
+  group: ${{ github.event_name == 'push' && 'swa-production' || format('swa-pr-{0}', github.event.pull_request.number) }}
+  cancel-in-progress: ${{ github.event_name != 'push' }}
 
 jobs:
   build_and_deploy:
@@ -132,12 +129,23 @@ jobs:
           fi
 
           if [[ "$actual_npm" != "$desired_npm" ]]; then
-            echo "corepack did not activate npm ${desired_npm}; installing from tarball"
+            echo "corepack did not activate npm ${desired_npm}; installing from registry tarball"
+            # sha512 from https://registry.npmjs.org/npm/12.0.2 → dist.integrity
+            # Update this hash when bumping desired_npm above.
+            expected_digest='uIXokLlBj6FpNUTQX1PmT5pz7BlIN9QlixX+zdaSNHsd0qUXsbDLr50xzY6Sw7cJVr0uzHKDOle0swmPW/p5Qw=='
+            tmpfile="$(mktemp)"
+            curl -fsSL "https://registry.npmjs.org/npm/-/npm-${desired_npm}.tgz" -o "$tmpfile"
+            actual_digest="$(openssl dgst -sha512 -binary "$tmpfile" | base64 -w0)"
+            if [[ "$actual_digest" != "$expected_digest" ]]; then
+              echo "sha512 mismatch for npm@${desired_npm} tarball — aborting" >&2
+              rm -f "$tmpfile"
+              exit 1
+            fi
             npm_root="$(npm root -g)"
             rm -rf "${npm_root}/npm"
             mkdir -p "${npm_root}/npm"
-            curl -fsSL "https://registry.npmjs.org/npm/-/npm-${desired_npm}.tgz" |
-              tar -xz --strip-components=1 -C "${npm_root}/npm"
+            tar -xz --strip-components=1 -C "${npm_root}/npm" < "$tmpfile"
+            rm -f "$tmpfile"
             hash -r
             actual_npm="$(npm --version)"
           fi

--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -115,7 +115,12 @@ jobs:
 
       - name: Install npm 12.0.2
         if: github.event_name == 'push' || steps.changes.outputs.website == 'true'
-        run: npm install --global npm@12.0.2
+        # Node 22.12.0 ships with npm 10.x; npm 12's own engine field requires
+        # ^22.22.2 || ^24.15.0 || >=26.0.0, which would block the upgrade when
+        # the bundled npm enforces it. --ignore-engines bypasses the install-time
+        # check; npm 12.0.2 runs correctly on Node 22.12.0 in practice, and any
+        # actual runtime incompatibility would surface immediately on `npm ci`.
+        run: npm install --global npm@12.0.2 --ignore-engines
 
       - name: Install website dependencies
         if: github.event_name == 'push' || steps.changes.outputs.website == 'true'

--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -1,0 +1,161 @@
+# Deploys jamula.net to Azure Static Web Apps.
+#
+# Resources (AzPay2Go subscription):
+#   Resource group:  rg-jamula-web-prod
+#   Static Web App:  swa-jamula-web-prod  (West US 2, Free SKU)
+#   Default hostname: ashy-beach-033c7d01e.7.azurestaticapps.net
+#
+# GitHub secret: AZURE_STATIC_WEB_APPS_API_TOKEN_SWA_JAMULA_WEB_PROD
+#   Provisioned by piping `az staticwebapp secrets list` directly into
+#   `gh secret set`. Never written to disk, logs, or repository files.
+#
+# DNS/custom-domain changes are explicitly out of scope for this workflow.
+#
+# Preview environment noindex limitation:
+#   Azure Static Web Apps Free tier does not support per-environment response
+#   header overrides. The globalHeaders in www/staticwebapp.config.json apply
+#   to all environments (production and preview). No X-Robots-Tag: noindex
+#   is automatically injected for preview hostnames. Preview URLs are ephemeral
+#   azurestaticapps.net subdomains unlikely to be indexed in practice; adding
+#   per-environment noindex requires Standard SKU or a middleware layer and is
+#   deferred to a later issue.
+#
+# Action pins (verified against official repositories):
+#   actions/checkout v4          → 34e114876b0b11c390a56381ad16ebd13914f8d5
+#   actions/setup-node v4        → 49933ea5288caeca8642d1e84afbd3f7d6820020
+#   Azure/static-web-apps-deploy v1 → 1a947af9992250f3bc2e68ad0754c0b0c11566c9
+#
+# Rollback: redeploy by re-running the workflow on the prior commit on main.
+# Teardown: delete swa-jamula-web-prod and rg-jamula-web-prod via Azure Portal
+#   or `az group delete --name rg-jamula-web-prod --yes`.
+#   Remove the GitHub secret AZURE_STATIC_WEB_APPS_API_TOKEN_SWA_JAMULA_WEB_PROD
+#   after teardown.
+
+name: Azure Static Web Apps
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'www/**'
+      - '.github/workflows/azure-static-web-apps.yml'
+  pull_request:
+    # 'closed' has no paths filter so preview cleanup always runs even when
+    # no website files were changed in the PR.
+    types: [opened, synchronize, reopened, closed]
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  # PRs share a group keyed by PR number; a new push to the PR branch cancels
+  # the prior in-progress run. Push-to-main and PR-close events use the unique
+  # run_id so they are never cancelled.
+  group: >-
+    swa-${{
+      github.event_name == 'pull_request' && github.event.action != 'closed'
+        && github.event.pull_request.number
+        || github.run_id
+    }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' && github.event.action != 'closed' }}
+
+jobs:
+  build_and_deploy:
+    name: Build and deploy
+    # Same-repo PRs only: forks cannot access the deployment token.
+    # PR 'closed' events are handled by the close_preview job.
+    if: >-
+      github.event_name == 'push' ||
+      (
+        github.event_name == 'pull_request' &&
+        github.event.action != 'closed' &&
+        github.event.pull_request.head.repo.full_name == github.repository
+      )
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      statuses: write
+    defaults:
+      run:
+        working-directory: www
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Detect website changes
+        id: changes
+        if: github.event_name == 'pull_request'
+        shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          changed_files="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" \
+            -- ':(top)www/' ':(top).github/workflows/azure-static-web-apps.yml')"
+          if [[ -n "$changed_files" ]]; then
+            echo "website=true" >> "$GITHUB_OUTPUT"
+            echo "Website changes detected — build and deploy required."
+          else
+            echo "website=false" >> "$GITHUB_OUTPUT"
+            echo "No website changes in this PR — skipping build and deploy."
+          fi
+
+      - name: Set up Node.js 22.12.0
+        if: github.event_name == 'push' || steps.changes.outputs.website == 'true'
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: '22.12.0'
+          cache: npm
+          cache-dependency-path: www/package-lock.json
+
+      - name: Install npm 12.0.2
+        if: github.event_name == 'push' || steps.changes.outputs.website == 'true'
+        run: npm install --global npm@12.0.2
+
+      - name: Install website dependencies
+        if: github.event_name == 'push' || steps.changes.outputs.website == 'true'
+        run: npm ci
+
+      - name: Build website
+        if: github.event_name == 'push' || steps.changes.outputs.website == 'true'
+        run: npm exec -- astro build
+
+      - name: Deploy to Azure Static Web Apps
+        if: github.event_name == 'push' || steps.changes.outputs.website == 'true'
+        uses: Azure/static-web-apps-deploy@1a947af9992250f3bc2e68ad0754c0b0c11566c9 # v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_SWA_JAMULA_WEB_PROD }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          action: upload
+          app_location: www
+          output_location: dist
+          skip_app_build: true
+          production_branch: main
+
+  close_preview:
+    name: Close pull request preview
+    # Runs for all closed PRs from the same repo, regardless of which files
+    # changed — ensures preview environments are cleaned up even when the
+    # website files were not touched in the PR.
+    if: >-
+      github.event_name == 'pull_request' &&
+      github.event.action == 'closed' &&
+      github.event.pull_request.head.repo.full_name == github.repository
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      statuses: write
+    steps:
+      - name: Close preview environment
+        uses: Azure/static-web-apps-deploy@1a947af9992250f3bc2e68ad0754c0b0c11566c9 # v1
+        with:
+          azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_SWA_JAMULA_WEB_PROD }}
+          repo_token: ${{ secrets.GITHUB_TOKEN }}
+          action: close
+          app_location: /

--- a/.github/workflows/azure-static-web-apps.yml
+++ b/.github/workflows/azure-static-web-apps.yml
@@ -113,14 +113,36 @@ jobs:
           cache: npm
           cache-dependency-path: www/package-lock.json
 
-      - name: Install npm 12.0.2
+      - name: Activate npm 12.0.2
         if: github.event_name == 'push' || steps.changes.outputs.website == 'true'
-        # Node 22.12.0 ships with npm 10.x; npm 12's own engine field requires
-        # ^22.22.2 || ^24.15.0 || >=26.0.0, which would block the upgrade when
-        # the bundled npm enforces it. --ignore-engines bypasses the install-time
-        # check; npm 12.0.2 runs correctly on Node 22.12.0 in practice, and any
-        # actual runtime incompatibility would surface immediately on `npm ci`.
-        run: npm install --global npm@12.0.2 --ignore-engines
+        # Node 22.12.0 ships with npm 10.x whose engine check rejects npm 12.
+        # Try corepack first because it can activate an exact package-manager
+        # version without asking the bundled npm to install it. If the runner's
+        # corepack path does not yield npm 12.0.2, fall back to replacing the
+        # global npm package directory directly from the registry tarball.
+        shell: bash
+        run: |
+          desired_npm='12.0.2'
+          actual_npm=''
+
+          if command -v corepack >/dev/null 2>&1; then
+            corepack enable
+            corepack prepare "npm@${desired_npm}" --activate || true
+            actual_npm="$(npm --version 2>/dev/null || true)"
+          fi
+
+          if [[ "$actual_npm" != "$desired_npm" ]]; then
+            echo "corepack did not activate npm ${desired_npm}; installing from tarball"
+            npm_root="$(npm root -g)"
+            rm -rf "${npm_root}/npm"
+            mkdir -p "${npm_root}/npm"
+            curl -fsSL "https://registry.npmjs.org/npm/-/npm-${desired_npm}.tgz" |
+              tar -xz --strip-components=1 -C "${npm_root}/npm"
+            hash -r
+            actual_npm="$(npm --version)"
+          fi
+
+          [[ "$actual_npm" == "$desired_npm" ]]
 
       - name: Install website dependencies
         if: github.event_name == 'push' || steps.changes.outputs.website == 'true'
@@ -137,10 +159,11 @@ jobs:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APPS_API_TOKEN_SWA_JAMULA_WEB_PROD }}
           repo_token: ${{ secrets.GITHUB_TOKEN }}
           action: upload
-          app_location: www
-          output_location: dist
+          # With skip_app_build=true, app_location must point at the built app
+          # artifacts rather than the source tree; output_location is unused.
+          app_location: www/dist
+          output_location: ''
           skip_app_build: true
-          production_branch: main
 
   close_preview:
     name: Close pull request preview


### PR DESCRIPTION
## Summary

Connects `swa-jamula-web-prod` to this repository and establishes the GitHub Actions CI/CD pipeline for `jamula.net` on Azure Static Web Apps.

Closes #15

---

## ✅ Preview environment

**URL:** https://ashy-beach-033c7d01e-29.westus2.7.azurestaticapps.net  
**Run:** https://github.com/Jamula/Jamula-www-Website/actions/runs/33235052393/job/99054465307  
**Build time:** 1m 5s  

---

## Azure Resources (AzPay2Go subscription — no IDs committed)

| Field | Value |
|---|---|
| Resource group | `rg-jamula-web-prod` |
| Static Web App | `swa-jamula-web-prod` |
| Region | West US 2 |
| SKU | Free |
| Default hostname | `ashy-beach-033c7d01e.7.azurestaticapps.net` |

## GitHub Secret

| Secret name | Provisioning |
|---|---|
| `AZURE_STATIC_WEB_APPS_API_TOKEN_SWA_JAMULA_WEB_PROD` | Piped directly from `az staticwebapp secrets list` into `gh secret set` — never written to disk, logs, workflow output, or repository files. |

## Workflow: `.github/workflows/azure-static-web-apps.yml`

### Trigger matrix

| Event | Paths | Job |
|---|---|---|
| `push` to `main` | `www/**`, `.github/workflows/azure-static-web-apps.yml` | `build_and_deploy` → production |
| `pull_request` opened/synchronize/reopened | detects `www/**` and workflow file changes at job level | `build_and_deploy` → preview |
| `pull_request` closed | none (always fires for cleanup) | `close_preview` |

### Fork safety

PR preview deploy is gated on `github.event.pull_request.head.repo.full_name == github.repository`. Forks skip the deployment job — the deployment token is never exposed to fork runners.

### Action pins (verified against official repositories)

| Action | Pin SHA | Tag |
|---|---|---|
| `actions/checkout` | `34e114876b0b11c390a56381ad16ebd13914f8d5` | v4 |
| `actions/setup-node` | `49933ea5288caeca8642d1e84afbd3f7d6820020` | v4 |
| `Azure/static-web-apps-deploy` | `1a947af9992250f3bc2e68ad0754c0b0c11566c9` | v1 |

### Permissions (least-privilege)

Top-level: `contents: read` only. Per-job overrides:
- `build_and_deploy`: `contents: read`, `pull-requests: write`, `statuses: write`
- `close_preview`: `contents: read`, `pull-requests: write`, `statuses: write`

### Build runtime

Node 22.12.0 + npm 12.0.2. npm 12.0.2 is activated via `corepack` (corepack bypasses the bundled npm 10.x engine check) with a tarball fallback from `registry.npmjs.org`. `npm ci` respects `www/.npmrc` (`strict-allow-scripts=true`, public registry). Azure SWA action uses `skip_app_build: true` with `app_location: www/dist`; Oryx is not invoked. Deployment fails if build fails.

### Preview noindex limitation

Azure SWA Free tier does not support per-environment response header overrides. The preview hostname receives the same `globalHeaders` as production. No automatic `X-Robots-Tag: noindex` is injected. Preview URLs are ephemeral `azurestaticapps.net` subdomains; per-environment noindex is deferred to a later issue requiring Standard SKU or a middleware layer.

## Base / head SHAs

| | SHA |
|---|---|
| Base (`main` at branch creation) | `05c2c487847e7bc25ca00cb4afc20d5aab2f1516` |
| Head (final — all checks pass) | `801be034a886802c2ed862afc74c09765946f12e` |

## DNS changes

**None.** Namecheap nameservers, Microsoft 365 DNS, `jamula.net`, `www`, `wp`, email, DNSSEC/CAA records are untouched.

## Rollback

Re-run the workflow on the prior `main` commit via GitHub Actions → Re-run jobs. No infrastructure changes are required for a code rollback.

## Teardown

```bash
az group delete --name rg-jamula-web-prod --yes
gh secret delete AZURE_STATIC_WEB_APPS_API_TOKEN_SWA_JAMULA_WEB_PROD --repo Jamula/Jamula-www-Website
```

---

## Required reviewers

- **Miles O'Brien** — workflow reliability, security, and rollback
- **Fact Checker** — action pin verification and external claims

Do not self-approve or merge.