### PR TITLE
Build the Standing Statement homepage (#48)

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,232 @@
+---
+name: Jamula.net — The Standing Statement
+description: A letterpress type-specimen system for Jamula's public homepage — green press-ink on proofing-stock paper.
+colors:
+  paper: "#e9e7df"
+  paper-deep: "#e0ddd1"
+  ink: "#1b1a16"
+  ink-soft: "#4a463c"
+  press: "#245a3a"
+  press-strong: "#17402a"
+  rule: "#b8b4a6"
+  rule-ink: "#2c2920"
+  paper-dark: "#17160f"
+  paper-deep-dark: "#201e15"
+  ink-dark: "#e9e7df"
+  ink-soft-dark: "#a8a394"
+  press-dark: "#63bd8d"
+typography:
+  display:
+    fontFamily: '"Iowan Old Style", "Palatino Linotype", "Book Antiqua", Palatino, "URW Palladio L", "Sorts Mill Goudy", Georgia, "Times New Roman", serif'
+    fontSize: "clamp(2rem, 1rem + 6.2vw, 5.75rem)"
+    fontWeight: 600
+    lineHeight: 0.98
+    letterSpacing: "-0.02em"
+  heading:
+    fontFamily: "{typography.display.fontFamily}"
+    fontSize: "clamp(1.7rem, 1.1rem + 2.6vw, 3rem)"
+    fontWeight: 600
+    lineHeight: 1.06
+    letterSpacing: "-0.02em"
+  body:
+    fontFamily: "{typography.display.fontFamily}"
+    fontSize: "1.0625rem"
+    fontWeight: 400
+    lineHeight: 1.62
+    letterSpacing: "normal"
+  label:
+    fontFamily: "{typography.display.fontFamily}"
+    fontSize: "0.875rem"
+    fontWeight: 600
+    lineHeight: 1.28
+    letterSpacing: "0.18em"
+rounded:
+  sm: "0"
+  md: "0"
+spacing:
+  "1": "0.25rem"
+  "2": "0.5rem"
+  "3": "0.75rem"
+  "4": "1rem"
+  "6": "1.5rem"
+  "8": "2rem"
+  "12": "3rem"
+  "16": "4rem"
+  "24": "6rem"
+components:
+  next-action:
+    textColor: "{colors.press}"
+    typography: "{typography.label}"
+    padding: "0"
+  specimen-tick:
+    backgroundColor: "{colors.press}"
+    width: "1rem"
+    height: "2px"
+  recombine-band:
+    backgroundColor: "{colors.paper-deep}"
+    textColor: "{colors.ink}"
+    padding: "4rem 2rem"
+---
+
+# Jamula.net Design System — The Standing Statement
+
+> This file describes the **built** homepage world (`www/src/pages/index.astro`
+> and its shared shell), not an aspiration. Product truth lives in `PRODUCT.md`;
+> the durable per-route strategy lives in
+> `.impeccable/surfaces/www-src-pages-index-astro.md`. Tokens above are
+> normative and map 1:1 to `www/src/styles/tokens.css`.
+
+## Overview
+
+The homepage is a **letterpress type specimen**. Jamula's one offer — AI
+strategy, custom software, and cloud consulting, delivered together — is set
+once as a standing statement, split into three legible specimen paths, and
+recombined into a single strategy-to-execution close. The world carries
+authority through set type and pressed rules rather than sales pressure: no
+cards, no gradients, no glass, no glow, no page-wide circuit motif.
+
+The single non-neutral ink is a deep **press-green** derived from the approved
+Jamula mark. It is used deliberately — over the terracotta/red default of
+generic AI editorial layouts — so the accent stays brand-honest.
+
+Two schemes are two physical readings of the same press:
+
+- **Light — positive impression:** warm near-black ink pressed into cool
+  proofing-stock paper.
+- **Dark — proof pull:** the paper reversed out of an inked field, with the
+  press-green lifted so it holds on the dark ground.
+
+## Colors
+
+Semantic roles (see `tokens.css` for the `--j-*` variable names). Every pairing
+below is measured against WCAG 2.2.
+
+**Light (positive impression)**
+
+| Role | Value | On paper (`#e9e7df`) |
+| --- | --- | --- |
+| `ink` (body) | `#1b1a16` | 14.5:1 |
+| `ink-soft` (secondary/labels) | `#4a463c` | 7.6:1 |
+| `press` (accent, links, marks) | `#245a3a` | 6.6:1 |
+| `rule` (hairlines) | `#b8b4a6` | structural, non-text |
+| `rule-ink` (heavy rules) | `#2c2920` | structural, non-text |
+
+On the `paper-deep` recombine band (`#e0ddd1`): ink 13.1:1, ink-soft 6.9:1,
+press 6.0:1.
+
+**Dark (proof pull)**
+
+| Role | Value | On field (`#17160f`) |
+| --- | --- | --- |
+| `ink` (body) | `#e9e7df` | 14.5:1 |
+| `ink-soft` | `#a8a394` | 7.3:1 |
+| `press` | `#63bd8d` | 8.3:1 |
+
+Color is committed at page scale as ink-and-paper fields, never as accents
+scattered over a neutral ground. `::selection` is press-green with paper text.
+
+## Typography
+
+One face does the work: a **bookish oldstyle serif** system stack (Iowan Old
+Style → Palatino → Book Antiqua → Georgia → serif). No web fonts are downloaded
+— the specimen voice comes from set type, not a loaded display face, which also
+keeps the font budget at zero and satisfies the site CSP (`font-src 'self'`).
+
+- **Standing statement (`display`)** — `clamp(2rem, 1rem + 6.2vw, 5.75rem)`,
+  weight 600, line-height 0.98, tracking −0.02em. Each offering line ends in a
+  small green terminal mark that foreshadows its specimen path.
+- **Section headings (`heading`)** — `clamp(1.7rem, 1.1rem + 2.6vw, 3rem)`.
+- **Body** — 1.0625rem / 1.62, oldstyle proportional numerals, measure capped
+  at ~34rem in specimen columns and ~60ch in passages.
+- **Labels** — the same serif in **letterspaced all-small-caps** (`0.18em`),
+  used for the quiet marks above each section and the maker's mark row.
+
+## Layout
+
+- Content max-width `74rem`, centered, with `1.5rem` inline gutters
+  (`1rem` at ≤32rem).
+- **The split:** a 3-column grid of specimen corridors separated by 1px
+  hairline rules, hung beneath a 3px heavy rule. Columns collapse to a single
+  stacked column at ≤52rem; the corridors then read top-to-bottom. The
+  split/recombine is expressed entirely through layout and type, so it remains
+  understandable in a single column and with motion disabled.
+- **The recombine:** a full-bleed `paper-deep` band whose top edge is a heavy
+  rule, with three short green corridors converging into it (one at ≤52rem).
+- Verified free of horizontal overflow at 320px, 768px, and 1440px, and at
+  200% zoom.
+
+## Elevation & Depth
+
+None. This world has **no shadows and no elevation** — depth is the physical
+impression of ink and rule on paper. `--j-shadow-sm` resolves to `none` and is
+retained only for token compatibility. Structure is carried by rule weight:
+hairline `1px`, medium `2px`, heavy `3px`.
+
+## Shapes
+
+Square. All radii are `0` — letterpress has no rounded chrome. Forms are
+rules, fields, and set type. The bullet in specimen lists is a short green
+**press-tick** (a 1rem × 2px bar), not a dot; list markers use `list-style:
+none` with the tick drawn via `::before`.
+
+## Components
+
+- **Site header** — a flat colophon bar closed by a heavy `rule-ink` rule.
+  Wordmark set in letterspaced small-caps; not sticky, so the page masthead
+  owns the top.
+- **Site footer** — legal-baseline colophon (small-caps mark + copyright)
+  above a heavy rule. The previous placeholder `/privacy` and `/legal` links
+  were removed because those routes do not exist and are out of scope; restore
+  them only when approved legal/privacy pages ship.
+- **Masthead** — pressed maker's mark (the approved favicon `J`, ~1.75rem,
+  `alt=""` since the wordmark is adjacent) + wordmark; then the standing
+  statement; then the green `Together — not as separate projects.` close and a
+  lead paragraph. No dominant call to action.
+- **Specimen path** — small-caps label, `heading`, body, a rule-topped
+  “What this engagement includes” list with green press-ticks.
+- **Next step** — an educational, on-page close. The one link is a same-page
+  anchor back to the recombine (`#synthesis`), set in small-caps. There is no
+  contact form, email, or action URL on the page.
+
+**Focus & motion (sidecar behavior, not frontmatter):**
+
+- **Focus:** `:focus-visible` draws a 3px solid `press` outline at 3px offset —
+  a pressed ink outline, never a glow.
+- **Motion:** one authored moment, gated by `prefers-reduced-motion:
+  no-preference` and layered only on decorative ink — the green terminal marks
+  press in (`scaleX`) and the three corridors draw down (`scaleY`). Text is
+  never hidden or moved, so the page reads fully from an already-visible
+  default and is complete with motion disabled.
+
+## Do's and Don'ts
+
+**Do**
+
+- Let set type and pressed rules carry hierarchy; add space above a heading,
+  less below.
+- Keep the press-green as the single accent, tied to the mark.
+- Use the maker's mark small and once, as a pressed mark.
+- Measure contrast independently in both schemes before shipping a new pairing.
+
+**Don't**
+
+- Add cards, gradients, glass, glow/neon, rounded chrome, or drop shadows.
+- Enlarge the `J` mark into page-wide circuit-board decoration.
+- Download web fonts or add client JavaScript, trackers, or third-party
+  requests (the homepage ships **zero** of each).
+- Hide content behind an entrance animation, or rely on motion to make a
+  layout legible.
+
+## Performance budgets (measured on the built homepage)
+
+| Asset | Budget (raw) | Measured (raw / gzip) |
+| --- | --- | --- |
+| HTML (`index.html`) | ≤ 20 KB | 13.4 KB / 4.0 KB |
+| CSS (all, 2 files) | ≤ 20 KB | 13.1 KB / 3.3 KB |
+| Client JS | **0 KB (hard)** | 0 KB |
+| Downloaded fonts | **0 (hard)** | 0 (system stack) |
+| Homepage images | ≤ 5 KB | 1.1 KB (favicon `J`, only image) |
+| Third-party requests | **0 (hard)** | 0 |
+
+Static output only; compatible with the site CSP (`default-src 'self'`,
+`font-src 'self'`, `script-src 'self'`).

--- a/www/src/components/SiteFooter.astro
+++ b/www/src/components/SiteFooter.astro
@@ -1,57 +1,49 @@
 ---
 /**
- * SiteFooter — site-wide footer with legal baseline.
+ * SiteFooter — letterpress colophon.
+ * Legal baseline only. The previous placeholder Privacy/Legal links pointed
+ * at routes that do not exist (/privacy, /legal) and are explicitly out of
+ * scope for this issue, so they are omitted rather than shipped as dead
+ * (404) links; add them back when approved legal/privacy pages exist.
  */
 const year = new Date().getFullYear();
 ---
 
 <footer class="site-footer">
   <div class="site-footer__inner">
+    <p class="site-footer__mark specimen-label">Jamula</p>
     <p class="site-footer__copy">
       &copy; {year} Jamula, Inc. All rights reserved.
     </p>
-    <nav aria-label="Footer navigation">
-      <ul class="site-footer__links" role="list">
-        <!-- Placeholder links — replace with approved privacy/legal URLs -->
-        <li><a href="/privacy">Privacy</a></li>
-        <li><a href="/legal">Legal</a></li>
-      </ul>
-    </nav>
   </div>
 </footer>
 
 <style>
   .site-footer {
-    border-block-start: 1px solid var(--j-color-border);
+    border-block-start: var(--j-rule-heavy) solid var(--j-rule-ink);
+    margin-block-start: var(--j-space-24);
     padding-block: var(--j-space-8);
-    margin-block-start: var(--j-space-16);
+    background-color: var(--j-color-bg);
   }
 
   .site-footer__inner {
     max-width: var(--j-max-width);
     margin-inline: auto;
-    padding-inline: var(--j-space-4);
+    padding-inline: var(--j-space-6);
     display: flex;
     flex-wrap: wrap;
-    align-items: center;
+    align-items: baseline;
     justify-content: space-between;
-    gap: var(--j-space-4);
+    gap: var(--j-space-3) var(--j-space-6);
+  }
+
+  .site-footer__mark {
+    letter-spacing: 0.24em;
   }
 
   .site-footer__copy {
     font-size: var(--j-text-sm);
     color: var(--j-color-text-subtle);
     max-width: none;
-  }
-
-  .site-footer__links {
-    display: flex;
-    gap: var(--j-space-6);
-    list-style: none;
-  }
-
-  .site-footer__links a {
-    font-size: var(--j-text-sm);
-    color: var(--j-color-text-subtle);
   }
 </style>

--- a/www/src/components/SiteHeader.astro
+++ b/www/src/components/SiteHeader.astro
@@ -1,7 +1,9 @@
 ---
 /**
- * SiteHeader — persistent site navigation.
- * Keyboard-accessible; uses a <nav> landmark with aria-label.
+ * SiteHeader — a quiet letterpress colophon bar.
+ * The standing statement owns the masthead on the page itself, so the
+ * header stays flat and restrained: wordmark set in the specimen face,
+ * closed by a pressed rule. Keyboard-accessible <nav> landmark.
  */
 ---
 
@@ -13,8 +15,8 @@
 
     <nav aria-label="Primary navigation">
       <ul class="site-header__nav" role="list">
-        <li><a href="/">Home</a></li>
-        <!-- Additional nav links will be added when content is approved -->
+        <li><a href="/" aria-current="page">Home</a></li>
+        <!-- Additional nav links will be added when content is approved. -->
       </ul>
     </nav>
   </div>
@@ -22,31 +24,29 @@
 
 <style>
   .site-header {
-    position: sticky;
-    top: 0;
-    z-index: 10;
     background-color: var(--j-color-bg);
-    border-block-end: 1px solid var(--j-color-border);
-    box-shadow: var(--j-shadow-sm);
+    border-block-end: var(--j-rule-heavy) solid var(--j-rule-ink);
   }
 
   .site-header__inner {
     display: flex;
-    align-items: center;
+    align-items: baseline;
     justify-content: space-between;
     gap: var(--j-space-4);
     max-width: var(--j-max-width);
     margin-inline: auto;
-    padding-inline: var(--j-space-4);
-    height: var(--j-header-height);
+    padding-inline: var(--j-space-6);
+    padding-block: var(--j-space-3);
   }
 
   .site-header__wordmark {
-    font-size: var(--j-text-xl);
-    font-weight: 700;
+    font-family: var(--j-font-serif);
+    font-size: var(--j-text-lg);
+    font-weight: 600;
+    font-variant-caps: all-small-caps;
+    letter-spacing: 0.14em;
     color: var(--j-color-text);
     text-decoration: none;
-    letter-spacing: -0.02em;
   }
 
   .site-header__wordmark:hover {
@@ -62,20 +62,18 @@
   .site-header__nav a {
     font-size: var(--j-text-sm);
     font-weight: 600;
+    font-variant-caps: all-small-caps;
+    letter-spacing: 0.1em;
     color: var(--j-color-text);
     text-decoration: none;
     padding-block: var(--j-space-1);
   }
 
-  .site-header__nav a:hover {
-    color: var(--j-color-accent);
-    text-decoration: underline;
-    text-underline-offset: 0.2em;
-  }
-
+  .site-header__nav a:hover,
   .site-header__nav a[aria-current="page"] {
     color: var(--j-color-accent);
     text-decoration: underline;
+    text-decoration-thickness: 2px;
     text-underline-offset: 0.2em;
   }
 </style>

--- a/www/src/pages/index.astro
+++ b/www/src/pages/index.astro
@@ -1,26 +1,211 @@
 ---
 /**
- * Home page — placeholder foundation for Jamula.net.
+ * Home — The Standing Statement.
  *
- * Content, imagery, and copy here are intentionally minimal.
- * They carry no approved marketing claims, private facts, or
- * brand assets. Replace in a follow-on content/design issue.
+ * Letterpress type-specimen homepage for Jamula.net (issue #48, parent #39).
+ * Copy is the reviewer-cleared homepage draft; blocked claims (#43-H-006,
+ * #43-H-007 Microsoft/Azure sentences, founder technical background, and any
+ * contact mechanism) are intentionally absent. See root DESIGN.md and the PR
+ * for the used/omitted claim ledger.
  */
 import BaseLayout from "../layouts/BaseLayout.astro";
 ---
 
 <BaseLayout
   title="Home"
-  description="Jamula — technology consulting."
+  description="Jamula works across AI strategy, custom software, and cloud consulting in a single engagement — so what we recommend is also what we build and run."
   canonicalUrl="https://jamula.net/"
 >
   <div class="home">
-    <section class="hero" aria-labelledby="hero-heading">
-      <div class="hero__inner">
-        <h1 id="hero-heading" class="hero__title">
-          <span class="hero__title-accent">Jamula</span>
-        </h1>
-        <p class="hero__lead">More to come.</p>
+    <!-- DESIGN CONTRACT — Homepage / The Standing Statement
+    THESIS: One offer set in type — AI strategy, custom software, and cloud
+      consulting delivered together — refusing the icon-card triptych and the
+      generic centered hero.
+    OWN-WORLD: A letterpress type specimen. Deep press-green ink and warm
+      near-black on cool proofing-stock paper; square edges, hairline and heavy
+      rules, an oldstyle serif, letterspaced small-caps labels. No gradients,
+      glass, glow, neon, or cards.
+    STORY: A visitor reads one standing statement, sees it divide into three
+      legible specimen paths, watches them recombine into a single
+      strategy-to-execution close, then takes a quiet on-page next step.
+    FIRST VIEWPORT: Nameplate "Jamula" with a small pressed J mark, top-left;
+      the three-line offer set large beneath a heavy rule; a lead paragraph. No
+      dominant call to action.
+    FORM: The Standing Statement (ranked 1 of the shaped list; brief-pinned).
+      Staging spatial-navigation-split-spectrum-corridors. Seed 6fe54e8e. -->
+
+    <!-- ── Masthead: the offer stated once, in type ─────────────── -->
+    <section class="masthead" aria-labelledby="site-name">
+      <h1 id="site-name" class="masthead__nameplate">
+        <img
+          class="masthead__mark"
+          src="/favicon-32x32.png"
+          alt=""
+          width="32"
+          height="32"
+          decoding="async"
+        />
+        <span class="masthead__name">Jamula</span>
+      </h1>
+
+      <p class="standing" aria-describedby="standing-close">
+        <span class="standing__line">AI strategy.</span>
+        <span class="standing__line">Custom software.</span>
+        <span class="standing__line">Cloud consulting.</span>
+      </p>
+      <p id="standing-close" class="standing__together">Together — not as separate projects.</p>
+
+      <p class="masthead__lead">
+        Organizations exploring AI often receive advice that stops before it reaches their systems.
+        Jamula doesn&rsquo;t stop there. We work across AI strategy, custom software, and cloud
+        infrastructure in a single engagement, so what we recommend is also what we build and run.
+      </p>
+    </section>
+
+    <!-- ── The split: three specimen paths ──────────────────────── -->
+    <div class="split" role="list" aria-label="What Jamula offers">
+      <section class="specimen" role="listitem" aria-labelledby="offer-ai">
+        <p class="specimen-label">One of three</p>
+        <h2 id="offer-ai" class="specimen__head">AI Strategy</h2>
+        <p>
+          Artificial intelligence creates real choices &mdash; and real ways to get them wrong.
+          Jamula helps organizations think clearly about AI: what it can do for your situation, what
+          it cannot do, and how to make a decision that holds up.
+        </p>
+        <p>
+          That means grounded scoping before any commitment, honest assessment of capability and
+          risk, and a strategy you can evaluate against something measurable &mdash; defined before
+          work starts.
+        </p>
+        <p class="specimen__includes-label specimen-label">What this engagement includes</p>
+        <ul class="specimen__list" role="list">
+          <li>Evaluation of AI fit for a specific business problem</li>
+          <li>Identification of the right approach, tools, and level of investment</li>
+          <li>Honest characterization of limitations and conditions for success</li>
+          <li>A decision frame that survives scrutiny &mdash; internally and from customers</li>
+        </ul>
+      </section>
+
+      <section class="specimen" role="listitem" aria-labelledby="offer-software">
+        <p class="specimen-label">Two of three</p>
+        <h2 id="offer-software" class="specimen__head">Custom Software</h2>
+        <p>
+          Off-the-shelf tools solve standard problems. When your problem isn&rsquo;t standard
+          &mdash; or when you&rsquo;re building the capability that makes your organization
+          different &mdash; custom software is the answer.
+        </p>
+        <p>
+          Jamula designs and builds software for the specific problem at hand: the workflow that
+          doesn&rsquo;t fit a template, the integration that existing products can&rsquo;t make, the
+          tool that turns your AI strategy into something your team actually uses.
+        </p>
+        <p class="specimen__includes-label specimen-label">What this engagement includes</p>
+        <ul class="specimen__list" role="list">
+          <li>Design and development of purpose-built applications and integrations</li>
+          <li>Architecture that separates your business logic from the platforms it runs on</li>
+          <li>Delivery with clear scope, a testable definition of done, and documented handoffs</li>
+          <li>
+            Software built to be operated, maintained, and eventually replaced &mdash; not locked in
+          </li>
+        </ul>
+      </section>
+
+      <section class="specimen" role="listitem" aria-labelledby="offer-cloud">
+        <p class="specimen-label">Three of three</p>
+        <h2 id="offer-cloud" class="specimen__head">Cloud Consulting</h2>
+        <p>
+          Cloud infrastructure done well is invisible &mdash; it doesn&rsquo;t slow software down,
+          it doesn&rsquo;t surprise you on a bill, and it doesn&rsquo;t create problems when you
+          need to move.
+        </p>
+        <p class="specimen__includes-label specimen-label">What this engagement includes</p>
+        <ul class="specimen__list" role="list">
+          <li>
+            Infrastructure design and implementation for cloud-hosted software and AI workloads
+          </li>
+          <li>
+            Cost, reliability, and operations planning &mdash; including the assumptions behind each
+            tradeoff
+          </li>
+          <li>Documentation sufficient to run, audit, and transfer the infrastructure</li>
+          <li>A path that keeps your options open</li>
+        </ul>
+      </section>
+    </div>
+
+    <!-- ── The recombine: three disciplines resolve into one ─────── -->
+    <section class="rejoin" id="synthesis" aria-labelledby="rejoin-head">
+      <div class="rejoin__corridors" aria-hidden="true">
+        <span></span><span></span><span></span>
+      </div>
+      <p class="specimen-label">The three, rejoined</p>
+      <h2 id="rejoin-head" class="rejoin__head">Three disciplines, one engagement</h2>
+      <div class="rejoin__body">
+        <p>
+          The problem with separate AI, software, and cloud engagements is that strategy
+          doesn&rsquo;t survive the handoffs. A strategy that can&rsquo;t be built doesn&rsquo;t get
+          used. Software that can&rsquo;t run in the cloud doesn&rsquo;t work at scale. Jamula keeps
+          all three under one engagement so decisions stay consistent from the whiteboard to the
+          server.
+        </p>
+        <p>
+          An engagement with Jamula typically starts with understanding: what you&rsquo;re trying to
+          accomplish, what you already have, and where the real constraints are. From there, we
+          recommend what we think you need &mdash; including when the answer is less than you might
+          expect &mdash; and carry that recommendation through design, build, and operation.
+        </p>
+      </div>
+    </section>
+
+    <!-- ── How we approach AI ───────────────────────────────────── -->
+    <section class="passage" aria-labelledby="approach-head">
+      <p class="specimen-label">Method</p>
+      <h2 id="approach-head" class="passage__head">How we approach AI</h2>
+      <div class="passage__body">
+        <p>
+          Jamula&rsquo;s work on AI starts from a practical question: what will this actually do,
+          for this organization, in this situation? That question is harder than it sounds.
+        </p>
+        <p>
+          Jamula starts by checking whether incomplete data, unclear objectives, or untested
+          assumptions are the real problem. We work to surface those problems early &mdash; before
+          the commitment, before the build &mdash; because an honest scoping conversation is more
+          valuable than a confident one.
+        </p>
+        <p>
+          We don&rsquo;t claim AI is safe by default, and we don&rsquo;t claim any particular AI
+          implementation is safe until we can evaluate it against something measurable. We aim to
+          make the evaluation criteria clear and to tell you what we find.
+        </p>
+      </div>
+    </section>
+
+    <!-- ── About Jamula ─────────────────────────────────────────── -->
+    <section class="passage passage--about" aria-labelledby="about-head">
+      <p class="specimen-label">About</p>
+      <h2 id="about-head" class="passage__head">About Jamula</h2>
+      <div class="passage__body">
+        <p class="passage__lede">Cyrus Jamula founded Jamula.</p>
+      </div>
+    </section>
+
+    <!-- ── A quiet next step (on-page; no contact mechanism) ────── -->
+    <section class="next" aria-labelledby="next-head">
+      <p class="specimen-label">Where to start</p>
+      <h2 id="next-head" class="next__head">Read it as one engagement</h2>
+      <div class="next__body">
+        <p>
+          If you&rsquo;re weighing whether AI has a real application in your organization, or
+          whether your software or infrastructure needs are something Jamula can help with, the
+          place to start is seeing how the three disciplines work as one.
+        </p>
+        <p>
+          We&rsquo;ll tell you honestly what we think &mdash; including whether we&rsquo;re a good
+          fit or whether someone else is better suited.
+        </p>
+        <p class="next__action">
+          <a href="#synthesis">Re-read how the three disciplines combine</a>
+        </p>
       </div>
     </section>
   </div>
@@ -28,36 +213,327 @@ import BaseLayout from "../layouts/BaseLayout.astro";
 
 <style>
   .home {
-    padding-block: var(--j-space-12);
-    padding-inline: var(--j-space-4);
     max-width: var(--j-max-width);
     margin-inline: auto;
+    padding-inline: var(--j-space-6);
   }
 
-  /* ── Hero ────────────────────────────────────────────────── */
-
-  .hero {
-    padding-block: var(--j-space-16);
+  /* ── Masthead ─────────────────────────────────────────────────── */
+  .masthead {
+    padding-block: clamp(var(--j-space-12), 8vw, var(--j-space-24)) var(--j-space-12);
   }
 
-  .hero__inner {
-    max-width: 42rem;
-  }
-
-  .hero__title {
-    font-size: clamp(var(--j-text-3xl), 5vw, var(--j-text-4xl));
+  .masthead__nameplate {
+    display: flex;
+    align-items: center;
+    gap: var(--j-space-3);
     margin-block-end: var(--j-space-6);
-    letter-spacing: -0.03em;
   }
 
-  .hero__title-accent {
+  .masthead__mark {
+    width: 1.75rem;
+    height: 1.75rem;
+    /* A pressed maker's mark, not page-wide circuitry. */
+  }
+
+  .masthead__name {
+    font-size: var(--j-text-xl);
+    font-weight: 600;
+    font-variant-caps: all-small-caps;
+    letter-spacing: 0.18em;
+    color: var(--j-color-text);
+  }
+
+  .standing {
+    font-size: var(--j-display-1);
+    line-height: 0.98;
+    letter-spacing: var(--j-tracking-display);
+    font-weight: 600;
+    max-width: none;
+    display: grid;
+    gap: 0.06em;
+    padding-block-start: var(--j-space-6);
+    border-block-start: var(--j-rule-heavy) solid var(--j-rule-ink);
+  }
+
+  .standing__line {
+    display: block;
+    min-inline-size: 0;
+    overflow-wrap: break-word;
+  }
+  /* Each offering foreshadows its specimen corridor with a green terminal. */
+  .standing__line::after {
+    content: "";
+    display: inline-block;
+    inline-size: 0.62em;
+    block-size: 0.09em;
+    margin-inline-start: 0.28em;
+    vertical-align: 0.2em;
+    background-color: var(--j-color-accent);
+  }
+
+  .standing__together {
+    font-size: var(--j-display-2);
+    line-height: var(--j-leading-snug);
+    letter-spacing: var(--j-tracking-display);
+    font-weight: 600;
+    max-width: 22ch;
+    margin-block-start: var(--j-space-4);
     color: var(--j-color-accent);
   }
 
-  .hero__lead {
+  .masthead__lead {
+    font-size: var(--j-text-xl);
+    line-height: var(--j-leading-snug);
+    color: var(--j-color-text);
+    max-width: 42ch;
+    margin-block-start: var(--j-space-8);
+  }
+
+  /* ── The split: three specimen corridors ─────────────────────── */
+  .split {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 0;
+    border-block-start: var(--j-rule-heavy) solid var(--j-rule-ink);
+  }
+
+  .specimen {
+    padding: var(--j-space-8) var(--j-space-6) var(--j-space-12);
+    border-inline-start: var(--j-hairline) solid var(--j-rule-color);
+  }
+  .specimen:first-child {
+    border-inline-start: 0;
+    padding-inline-start: 0;
+  }
+  .specimen:last-child {
+    padding-inline-end: 0;
+  }
+
+  .specimen__head {
+    font-size: var(--j-text-2xl);
+    margin-block: var(--j-space-2) var(--j-space-4);
+  }
+
+  .specimen p {
+    color: var(--j-color-text);
+    margin-block-end: var(--j-space-4);
+    max-width: var(--j-measure);
+  }
+
+  .specimen__includes-label {
+    margin-block-start: var(--j-space-6);
+    padding-block-start: var(--j-space-3);
+    border-block-start: var(--j-hairline) solid var(--j-rule-color);
+  }
+
+  .specimen__list {
+    list-style: none;
+    margin-block-start: var(--j-space-3);
+    display: grid;
+    gap: var(--j-space-3);
+  }
+  .specimen__list li {
+    position: relative;
+    padding-inline-start: var(--j-space-6);
+    color: var(--j-color-text);
+    line-height: var(--j-leading-snug);
+  }
+  /* A small green press-tick, not a bullet dot. */
+  .specimen__list li::before {
+    content: "";
+    position: absolute;
+    inset-inline-start: 0;
+    inset-block-start: 0.62em;
+    inline-size: var(--j-space-4);
+    block-size: 2px;
+    background-color: var(--j-color-accent);
+  }
+
+  /* ── The recombine ────────────────────────────────────────────── */
+  .rejoin {
+    position: relative;
+    background-color: var(--j-color-surface);
+    margin-block-start: 0;
+    padding: var(--j-space-16) var(--j-space-8) var(--j-space-16);
+    /* full-bleed within the content column edges */
+    margin-inline: calc(-1 * var(--j-space-6));
+    padding-inline: var(--j-space-8);
+  }
+
+  /* Three short corridors converge into one heavy rule at the band's top. */
+  .rejoin__corridors {
+    position: absolute;
+    inset-block-start: 0;
+    inset-inline: var(--j-space-8);
+    block-size: var(--j-space-8);
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    justify-items: center;
+  }
+  .rejoin__corridors span {
+    inline-size: 2px;
+    block-size: 100%;
+    background-color: var(--j-color-accent);
+  }
+  .rejoin::before {
+    content: "";
+    position: absolute;
+    inset-block-start: 0;
+    inset-inline: 0;
+    block-size: var(--j-rule-heavy);
+    background-color: var(--j-rule-ink);
+  }
+
+  .rejoin__head {
+    font-size: var(--j-display-2);
+    max-width: 20ch;
+    margin-block: var(--j-space-2) var(--j-space-6);
+  }
+  .rejoin__body {
+    display: grid;
+    gap: var(--j-space-4);
+    max-width: 60ch;
+  }
+  .rejoin__body p {
     font-size: var(--j-text-lg);
-    color: var(--j-color-text-subtle);
-    line-height: var(--j-leading-normal);
-    max-width: var(--j-content-width);
+  }
+
+  /* ── Passages: method, about ─────────────────────────────────── */
+  .passage {
+    padding-block: var(--j-space-16);
+    border-block-start: var(--j-hairline) solid var(--j-rule-color);
+  }
+  .passage__head {
+    font-size: var(--j-text-3xl);
+    margin-block: var(--j-space-2) var(--j-space-6);
+  }
+  .passage__body {
+    display: grid;
+    gap: var(--j-space-4);
+    max-width: 60ch;
+  }
+  .passage__body p {
+    font-size: var(--j-text-lg);
+  }
+  .passage__lede {
+    font-size: var(--j-text-2xl);
+    line-height: var(--j-leading-snug);
+    color: var(--j-color-text);
+    font-weight: 600;
+    letter-spacing: -0.01em;
+  }
+
+  /* ── Next step ───────────────────────────────────────────────── */
+  .next {
+    padding-block: var(--j-space-16) var(--j-space-8);
+    border-block-start: var(--j-rule-heavy) solid var(--j-rule-ink);
+  }
+  .next__head {
+    font-size: var(--j-text-3xl);
+    margin-block: var(--j-space-2) var(--j-space-6);
+  }
+  .next__body {
+    display: grid;
+    gap: var(--j-space-4);
+    max-width: 56ch;
+  }
+  .next__body p {
+    font-size: var(--j-text-lg);
+  }
+  .next__action {
+    margin-block-start: var(--j-space-2);
+  }
+  .next__action a {
+    font-variant-caps: all-small-caps;
+    letter-spacing: 0.08em;
+    font-size: var(--j-text-lg);
+    text-decoration-thickness: 2px;
+  }
+
+  /* ── Responsive: specimens stack, corridors read top-to-bottom ── */
+  @media (max-width: 52rem) {
+    .split {
+      grid-template-columns: 1fr;
+    }
+    .specimen {
+      border-inline-start: 0;
+      padding-inline: 0;
+      padding-block: var(--j-space-8);
+      border-block-start: var(--j-hairline) solid var(--j-rule-color);
+    }
+    .specimen:first-child {
+      border-block-start: 0;
+    }
+    .rejoin__corridors {
+      grid-template-columns: 1fr;
+    }
+    .rejoin__corridors span:not(:first-child) {
+      display: none;
+    }
+  }
+
+  @media (max-width: 32rem) {
+    .home {
+      padding-inline: var(--j-space-4);
+    }
+    .rejoin {
+      margin-inline: calc(-1 * var(--j-space-4));
+      padding-inline: var(--j-space-4);
+    }
+    .rejoin__corridors {
+      inset-inline: var(--j-space-4);
+    }
+    .masthead__lead {
+      font-size: var(--j-text-lg);
+    }
+  }
+
+  /* ── One authored moment (enhancement only) ──────────────────────
+     Motion is layered onto decorative ink only — the green terminal marks
+     that end each offering, and the three corridors that converge into the
+     recombine band. Text is never hidden or moved, so the page reads fully
+     from an already-visible default and survives with motion disabled. */
+  @media (prefers-reduced-motion: no-preference) {
+    .standing__line::after {
+      transform-origin: left center;
+      animation: mark-press 520ms var(--j-ease-press) both;
+    }
+    .standing__line:nth-child(1)::after {
+      animation-delay: 120ms;
+    }
+    .standing__line:nth-child(2)::after {
+      animation-delay: 240ms;
+    }
+    .standing__line:nth-child(3)::after {
+      animation-delay: 360ms;
+    }
+    .rejoin__corridors span {
+      transform-origin: top center;
+      animation: corridor-draw 620ms var(--j-ease-press) both;
+    }
+    .rejoin__corridors span:nth-child(2) {
+      animation-delay: 90ms;
+    }
+    .rejoin__corridors span:nth-child(3) {
+      animation-delay: 180ms;
+    }
+  }
+
+  @keyframes mark-press {
+    from {
+      transform: scaleX(0);
+    }
+    to {
+      transform: scaleX(1);
+    }
+  }
+  @keyframes corridor-draw {
+    from {
+      transform: scaleY(0);
+    }
+    to {
+      transform: scaleY(1);
+    }
   }
 </style>

--- a/www/src/styles/base.css
+++ b/www/src/styles/base.css
@@ -1,4 +1,4 @@
-/* Base / reset — opinionated minimal reset */
+/* Base — letterpress editorial ground for The Standing Statement. */
 
 *,
 *::before,
@@ -12,9 +12,11 @@ html {
   font-size: 100%; /* respect browser default (typically 16px) */
   scroll-behavior: smooth;
   -webkit-text-size-adjust: 100%;
+  /* Paper never runs out under a short page. */
+  background-color: var(--j-color-bg);
 }
 
-/* Honour reduced-motion everywhere */
+/* Honour reduced-motion everywhere; motion is enhancement only. */
 @media (prefers-reduced-motion: reduce) {
   *,
   *::before,
@@ -27,13 +29,17 @@ html {
 }
 
 body {
-  font-family: var(--j-font-sans);
+  font-family: var(--j-font-serif);
   font-size: var(--j-text-base);
   line-height: var(--j-leading-normal);
   color: var(--j-color-text);
   background-color: var(--j-color-bg);
   min-height: 100dvh;
-  text-rendering: optimizeSpeed;
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  font-kerning: normal;
+  /* Oldstyle figures + real ligatures suit the specimen voice. */
+  font-variant-numeric: oldstyle-nums proportional-nums;
 }
 
 /* ── Typography ──────────────────────────────────────────────── */
@@ -45,7 +51,9 @@ h4,
 h5,
 h6 {
   line-height: var(--j-leading-tight);
-  font-weight: 700;
+  font-weight: 600;
+  letter-spacing: var(--j-tracking-display);
+  text-wrap: balance;
 }
 
 p,
@@ -53,23 +61,32 @@ li,
 dt,
 dd {
   max-width: var(--j-content-width);
+  text-wrap: pretty;
+}
+
+/* Ink selection, not browser blue. */
+::selection {
+  background-color: var(--j-color-accent);
+  color: var(--j-color-bg);
 }
 
 a {
   color: var(--j-color-accent);
-  text-decoration: underline;
-  text-underline-offset: 0.2em;
+  text-decoration-line: underline;
+  text-decoration-thickness: 1px;
+  text-underline-offset: 0.18em;
   transition: color var(--j-transition-fast);
 }
 
 a:hover {
   color: var(--j-color-accent-hover);
+  text-decoration-thickness: 2px;
 }
 
-/* Visible focus for all interactive elements */
+/* Visible focus — a pressed ink outline, not a glow. */
 :focus-visible {
-  outline: 3px solid var(--j-color-focus-ring);
-  outline-offset: 2px;
+  outline: var(--j-rule-heavy) solid var(--j-color-focus-ring);
+  outline-offset: 3px;
   border-radius: var(--j-radius-sm);
 }
 
@@ -92,17 +109,19 @@ svg {
   padding: var(--j-space-2) var(--j-space-4);
   background: var(--j-color-skip-link-bg);
   color: var(--j-color-skip-link-fg);
-  font-weight: 700;
+  font-weight: 600;
+  letter-spacing: 0.04em;
   border-radius: var(--j-radius-sm);
   text-decoration: none;
-  /* Hidden until focused */
-  transform: translateY(-150%);
+  /* Hidden until focused. */
+  transform: translateY(-160%);
   transition: transform var(--j-transition-fast);
   z-index: 100;
 }
 
 .skip-link:focus-visible {
   transform: translateY(0);
+  outline-offset: 2px;
 }
 
 /* ── Utilities ───────────────────────────────────────────────── */
@@ -117,4 +136,16 @@ svg {
   clip: rect(0, 0, 0, 0);
   white-space: nowrap;
   border: 0;
+}
+
+/* Letterpress specimen label — letterspaced small caps, used for the
+   quiet marks above section headings and on specimen columns. */
+.specimen-label {
+  font-family: var(--j-font-serif);
+  font-size: var(--j-text-sm);
+  font-weight: 600;
+  font-variant-caps: all-small-caps;
+  letter-spacing: var(--j-tracking-label);
+  text-transform: lowercase; /* small-caps renders these as caps glyphs */
+  color: var(--j-color-text-subtle);
 }

--- a/www/src/styles/tokens.css
+++ b/www/src/styles/tokens.css
@@ -1,41 +1,72 @@
 /*
- * Jamula design tokens — placeholder values for Phase 1 foundation.
- * All colours, spacing, and type scale are provisional; replace with
- * approved brand values in a follow-on design issue.
+ * Jamula design tokens — The Standing Statement.
  *
+ * A letterpress / type-specimen world: ink pressed into proofing stock.
+ * Light scheme is a positive impression (ink on paper); dark scheme is a
+ * proof pull (paper reversed out of an inked field). The single non-neutral
+ * ink is a deep press-green derived from the approved Jamula mark — chosen
+ * deliberately over the terracotta/red default so the accent stays
+ * brand-honest and off the generic path.
+ *
+ * Durable rationale lives in root DESIGN.md, written from the built world.
  * Convention: --j-<category>-<name>
  */
 
 :root {
-  /* ── Colour ──────────────────────────────────────────────────── */
-  --j-color-bg: #ffffff;
-  --j-color-surface: #f9f9f9;
-  --j-color-border: #e0e0e0;
-  --j-color-text: #111111;
-  --j-color-text-subtle: #555555;
-  --j-color-accent: #005ea2; /* WCAG AA on white for normal text */
-  --j-color-accent-hover: #003d7a;
-  --j-color-focus-ring: #0078d4;
+  /* ── Ink & paper (light = positive impression) ───────────────── */
+  --j-paper: #e9e7df; /* proofing stock, cool-neutral putty (not cream) */
+  --j-paper-deep: #e0ddd1; /* pressed panel / recombine band */
+  --j-ink: #1b1a16; /* warm near-black ink */
+  --j-ink-soft: #4a463c; /* second-pull ink for secondary text */
+  --j-press: #245a3a; /* deep press-green ink (brand-derived) */
+  --j-press-strong: #17402a; /* heavier green pull for hover/press */
+  --j-rule-color: #b8b4a6; /* hairline rule ink on paper */
+  --j-rule-ink: #2c2920; /* strong rule (masthead / recombine) */
 
-  /* ── Skip-link safe pair ─────────────────────────────────────── */
-  /* Light: #005ea2 bg + #ffffff fg → 6.17:1 (WCAG 2.2 AA ✓) */
-  --j-color-skip-link-bg: #005ea2;
-  --j-color-skip-link-fg: #ffffff;
+  /* ── Semantic aliases (names preserved for shared components) ── */
+  --j-color-bg: var(--j-paper);
+  --j-color-surface: var(--j-paper-deep);
+  --j-color-border: var(--j-rule-color);
+  --j-color-text: var(--j-ink);
+  --j-color-text-subtle: var(--j-ink-soft);
+  --j-color-accent: var(--j-press);
+  --j-color-accent-hover: var(--j-press-strong);
+  --j-color-focus-ring: var(--j-press);
+
+  /* Skip-link pair — press-green field, paper reversed out.
+     Light: #e9e7df on #1d4a32 → 8.1:1 (WCAG 2.2 AA ✓) */
+  --j-color-skip-link-bg: #1d4a32;
+  --j-color-skip-link-fg: #f1efe8;
 
   /* ── Typography ──────────────────────────────────────────────── */
-  --j-font-sans: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
-  --j-font-mono: ui-monospace, "Cascadia Code", "Fira Code", Consolas, monospace;
+  /* Self-hosted / system faces only — no remote font calls (CSP font-src 'self').
+     A bookish oldstyle serif carries the specimen voice; the same face set in
+     letterspaced small-caps carries specimen labels. */
+  --j-font-serif:
+    "Iowan Old Style", "Palatino Linotype", "Book Antiqua", Palatino, "URW Palladio L",
+    "Sorts Mill Goudy", Georgia, "Times New Roman", serif;
+  --j-font-sans: var(--j-font-serif); /* preserve name; the world is serif-led */
+  --j-font-mono:
+    ui-monospace, "Cascadia Code", "SFMono-Regular", Consolas, "Liberation Mono", monospace;
 
-  --j-text-base: 1rem;
+  /* Type scale — editorial, with a large standing-statement display. */
   --j-text-sm: 0.875rem;
-  --j-text-lg: 1.125rem;
-  --j-text-xl: 1.25rem;
-  --j-text-2xl: 1.5rem;
-  --j-text-3xl: 1.875rem;
-  --j-text-4xl: 2.25rem;
+  --j-text-base: 1.0625rem;
+  --j-text-lg: 1.1875rem;
+  --j-text-xl: 1.375rem;
+  --j-text-2xl: 1.75rem;
+  --j-text-3xl: 2.25rem;
+  --j-text-4xl: 2.75rem;
+  /* Standing statement + section marks (clamped, never past 6rem display). */
+  --j-display-1: clamp(2rem, 1rem + 6.2vw, 5.75rem);
+  --j-display-2: clamp(1.7rem, 1.1rem + 2.6vw, 3rem);
 
-  --j-leading-tight: 1.2;
-  --j-leading-normal: 1.6;
+  --j-leading-tight: 1.06;
+  --j-leading-snug: 1.28;
+  --j-leading-normal: 1.62;
+
+  --j-tracking-display: -0.02em;
+  --j-tracking-label: 0.18em; /* letterspaced small-caps specimen labels */
 
   /* ── Spacing ─────────────────────────────────────────────────── */
   --j-space-1: 0.25rem;
@@ -46,37 +77,45 @@
   --j-space-8: 2rem;
   --j-space-12: 3rem;
   --j-space-16: 4rem;
+  --j-space-24: 6rem;
 
   /* ── Layout ──────────────────────────────────────────────────── */
-  --j-max-width: 72rem;
-  --j-content-width: 65ch;
+  --j-max-width: 74rem;
+  --j-content-width: 68ch;
+  --j-measure: 34rem; /* specimen column measure */
   --j-header-height: 3.5rem;
 
-  /* ── Radius ──────────────────────────────────────────────────── */
-  --j-radius-sm: 0.25rem;
-  --j-radius-md: 0.5rem;
+  /* ── Rule weights (letterpress lines do the structural work) ─── */
+  --j-hairline: 1px;
+  --j-rule-medium: 2px;
+  --j-rule-heavy: 3px;
 
-  /* ── Shadow ──────────────────────────────────────────────────── */
-  --j-shadow-sm: 0 1px 3px 0 rgb(0 0 0 / 0.1);
+  /* ── Radius (kept square; letterpress has no rounded chrome) ─── */
+  --j-radius-sm: 0;
+  --j-radius-md: 0;
+
+  /* ── Shadow (unused as decoration; kept for token compatibility) */
+  --j-shadow-sm: none;
 
   /* ── Transition ──────────────────────────────────────────────── */
-  --j-transition-fast: 150ms ease;
+  --j-transition-fast: 160ms ease;
+  --j-ease-press: cubic-bezier(0.2, 0.7, 0.2, 1);
 }
 
-/* Dark-mode token overrides (system preference only; no JS toggle yet) */
+/* Dark scheme — proof pull: paper reversed out of an inked field. */
 @media (prefers-color-scheme: dark) {
   :root {
-    --j-color-bg: #0d0d0d;
-    --j-color-surface: #1a1a1a;
-    --j-color-border: #2e2e2e;
-    --j-color-text: #f0f0f0;
-    --j-color-text-subtle: #aaaaaa;
-    --j-color-accent: #4dabf7;
-    --j-color-accent-hover: #74c0fc;
-    --j-color-focus-ring: #4dabf7;
+    --j-paper: #17160f; /* inked field */
+    --j-paper-deep: #201e15; /* pressed panel / recombine band */
+    --j-ink: #e9e7df; /* paper reversed out */
+    --j-ink-soft: #a8a394; /* second-pull, softer paper */
+    --j-press: #63bd8d; /* press-green lifted for the dark field */
+    --j-press-strong: #8fd3ac;
+    --j-rule-color: #3a362a; /* hairline rule on the inked field */
+    --j-rule-ink: #6f6a58; /* strong rule */
 
-    /* Dark: #003d7a bg + #ffffff fg → 9.57:1 (WCAG 2.2 AA ✓) */
-    --j-color-skip-link-bg: #003d7a;
-    --j-color-skip-link-fg: #ffffff;
+    /* Dark: #17160f on #63bd8d → 8.3:1 (WCAG 2.2 AA ✓) */
+    --j-color-skip-link-bg: #63bd8d;
+    --j-color-skip-link-fg: #17160f;
   }
 }


### PR DESCRIPTION
## Summary

Replaces the placeholder homepage with **The Standing Statement** — the letterpress type-specimen world approved in #42. Jamula's one offer is set once as a standing statement, **split into three specimen paths** (AI Strategy · Custom Software · Cloud Consulting), and **recombined** into a single strategy-to-execution close, ending in a quiet on-page next step. No dominant CTA.

`Closes #48.` Child of #39.

## Source contracts (SHAs)

- Base / branched from `origin/main` **`f7fb6962419c9807570243c959b7a7bd600f2a50`**
- PR head **`30cbe35915855b5f0227a65c0063f0687f3b2759`**
- `PRODUCT.md` (current main, approved)
- `.impeccable/surfaces/www-src-pages-index-astro.md` — seed `6fe54e8e`, staging `spatial-navigation-split-spectrum-corridors`
- Reviewer-cleared copy: `docs/content/homepage-copy-draft.md` (corrected head `b7c876e5989b1f453c6ad1d397f1b3b2759ae809`, now in main `f7fb6962`)

## Exact changed paths (issue-owned only)

- `www/src/pages/index.astro` — the homepage world
- `www/src/styles/tokens.css` — letterpress token system (names preserved for shared components)
- `www/src/styles/base.css` — serif ground, focus, skip link, specimen-label utility
- `www/src/components/SiteHeader.astro` — flat colophon bar
- `www/src/components/SiteFooter.astro` — legal-baseline colophon
- `DESIGN.md` — written from the built world

`BaseLayout.astro` needed no change and was left untouched. No workflows, package/lock, SWA config, `PRODUCT.md`, docs, DNS, Azure, or Squad state were modified.

## Claim ledger

**Published (reviewer-cleared):**
| ID | Section | Notes |
|---|---|---|
| #43-H-001 | Standing statement | Offer categories, exact wording |
| #43-H-002 | Standing statement + synthesis | “Together — not as separate projects.” |
| #43-H-003 / #43-H-004 | AI Strategy | Exact wording |
| #43-H-005 | Custom Software | Exact wording |
| #43-H-008 | Synthesis | Exact wording (+ #43-H-002 reprise) |
| #43-H-009 / #43-H-010 | How we approach AI | Exact wording (Rai GREEN) |
| #43-F-001 | About Jamula | “Cyrus Jamula founded Jamula.” only |
| #43-H-011 | Next step | **Adapted** — see below |

**Adaptation (for Nyota):** #43-H-011’s contact-conversation tail (“the right place to start is a direct conversation”) is replaced with an on-page educational next step (“the place to start is seeing how the three disciplines work as one”) linking to `#synthesis`. The approved honest-fit sentence is kept verbatim. This honors the education-first posture and the no-contact-mechanism constraint. No claim meaning changed; only the CTA target moved to on-page reading.

**Blocked / omitted — proven absent** (grep on built `dist/index.html`, all counts `0`): `Microsoft`, `Azure`, `BLOCKED`, `REVIEW-GATED`, `mailto`, `book a call`, `get started`, `request a demo`, `LinkedIn`.
- #43-H-006 / #43-H-007 Microsoft/Azure sentences — omitted.
- #43-F-002 founder technical background — omitted; founder copy limited to approved identification.
- Contact mechanism (form / email / action URL / mailto) — none added.
- The draft’s “That expertise exists to give organizations optionality…” sentence is **also omitted**, because its antecedent (“That expertise”) is the blocked #43-H-006 Microsoft/Azure claim; publishing it alone would dangle or imply the blocked claim.

**Also for Sarek/Geordi:** the footer’s placeholder `/privacy` and `/legal` links were removed — those routes don’t exist and are out of scope, so they’d ship as 404s. Restore when approved legal/privacy pages exist.

## Design contract (emitted in production markup)

Verified present in `dist/index.html` (141 words; seed + staging included):
```
THESIS: One offer set in type — AI strategy, custom software, and cloud
  consulting delivered together — refusing the icon-card triptych and the
  generic centered hero.
OWN-WORLD: A letterpress type specimen. Deep press-green ink and warm
  near-black on cool proofing-stock paper; square edges, hairline and heavy
  rules, an oldstyle serif, letterspaced small-caps labels. No gradients,
  glass, glow, neon, or cards.
STORY: A visitor reads one standing statement, sees it divide into three
  legible specimen paths, watches them recombine into a single
  strategy-to-execution close, then takes a quiet on-page next step.
FIRST VIEWPORT: Nameplate "Jamula" with a small pressed J mark, top-left;
  the three-line offer set large beneath a heavy rule; a lead paragraph. No
  dominant call to action.
FORM: The Standing Statement (ranked 1; brief-pinned). Staging
  spatial-navigation-split-spectrum-corridors. Seed 6fe54e8e.
```

## Validation

- `prettier --check` (owned files): **pass**.
- `npm run check` (astro check): **0 errors / 0 warnings / 0 hints**.
- `npm run build`: **success**; design-contract HTML comment confirmed in `dist/index.html` (survives compression).
- **Impeccable detector** (`detect.mjs --json dist/index.html`): 1 finding — `em-dash-overuse` (advisory). All 15 em-dashes originate in the reviewer-cleared copy; not rewritten (would alter approved wording). No substantive/blocking findings; no cards/gradients/glass/neon/contrast findings.

## Accessibility (measured via DevTools protocol)

- Single `<h1>`; heading order matches the copy contract (AI → Custom → Cloud → synthesis → method → about → next).
- Landmarks: header / nav (labeled) / main / footer; offerings as a labeled list.
- All `aria-labelledby`/`aria-describedby` refs resolve in built HTML.
- Skip link → `#main-content`; visible 3px focus outline; maker’s-mark img `alt=""` (wordmark adjacent); all links have discernible names.
- `prefers-reduced-motion: reduce` → animations `none` (content static, fully legible). The only motion is decorative marks/corridors under `no-preference`; text is never hidden.
- **No horizontal overflow** at **320 / 768 / 1440 px** (`scrollWidth == clientWidth`); no overflowing elements. Reflow safe at 200%.
- Contrast (both schemes, measured): body ink ≥ 14:1, secondary/labels ≥ 7:1, press-green accent ≥ 6:1 light / 8:1 dark.

## Screenshots (evidence captured; not committed)

Device-emulated, both schemes, animation settled — captured to the session workspace (no machine-local paths committed):
- `320 light` / `320 dark` (true mobile), `768 light` (tablet), `1440 light` / `1440 dark` (desktop).
- Result: standing statement, split into three specimen corridors, the recombine band, method, founder line, and on-page next step all render correctly; dark scheme reads as a deliberate proof pull.

## Performance budgets (measured on built homepage)

| Asset | Budget (raw) | Measured raw / gzip |
|---|---|---|
| HTML | ≤ 20 KB | 13.4 KB / 4.0 KB |
| CSS (2 files) | ≤ 20 KB | 13.1 KB / 3.3 KB |
| Client JS | **0 (hard)** | 0 |
| Downloaded fonts | **0 (hard)** | 0 (system serif stack) |
| Homepage images | ≤ 5 KB | 1.1 KB (favicon `J`, only image) |
| Third-party requests | **0 (hard)** | 0 |

CSP-compatible (`default-src 'self'`, `font-src 'self'`, `script-src 'self'`).

## Known risks / notes

- Em-dash density is inherent to the cleared copy (advisory only).
- Typeface is a system oldstyle-serif stack; exact rendering varies by OS (Iowan/Palatino/Book Antiqua/Georgia), all bookish. No web font is downloaded by design.
- The dark scheme is system-preference only (no toggle), matching existing behavior.

## Rollback

Revert this single commit (`30cbe35`) / close this PR — `main` is untouched (PR preview only), which restores the previous placeholder homepage. No infra, config, or data changes.

## Reviews required before merge (do not merge)

Nyota (copy fidelity) · Geordi (Astro/build/deploy) · Miles (a11y/perf/security) · Fact Checker (claims) · Sarek (legal/endorsement/privacy) · Rai (responsible-AI) · then Cyrus exact-SHA approval. Awaiting PR validation + Azure preview.