### PR TITLE
Correct internal dark-mode contrast annotations

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -120,7 +120,7 @@ press 6.0:1.
 | --- | --- | --- |
 | `ink` (body) | `#e9e7df` | 14.5:1 |
 | `ink-soft` | `#a8a394` | 7.3:1 |
-| `press` | `#63bd8d` | 8.3:1 |
+| `press` | `#63bd8d` | 7.9:1 |
 
 Color is committed at page scale as ink-and-paper fields, never as accents
 scattered over a neutral ground. `::selection` is press-green with paper text.

--- a/www/src/styles/tokens.css
+++ b/www/src/styles/tokens.css
@@ -114,7 +114,7 @@
     --j-rule-color: #3a362a; /* hairline rule on the inked field */
     --j-rule-ink: #6f6a58; /* strong rule */
 
-    /* Dark: #17160f on #63bd8d → 8.3:1 (WCAG 2.2 AA ✓) */
+    /* Dark: #17160f on #63bd8d → 7.9:1 (WCAG 2.2 AA ✓) */
     --j-color-skip-link-bg: #63bd8d;
     --j-color-skip-link-fg: #17160f;
   }


### PR DESCRIPTION
Closes #50

Working as Miles O'Brien (Quality & Reliability Engineer)

## Issue

The WCAG relative-luminance contrast for `#63bd8d` (press-green accent) on `#17160f` (dark mode field) was documented as **8.3:1** but the actual calculated value is **7.9:1**.

## What Changed

- **www/src/styles/tokens.css**: Updated dark mode skip-link comment from 8.3:1 to 7.9:1
- **DESIGN.md**: Updated dark scheme color table from 8.3:1 to 7.9:1

Both annotations now use the same verified value with consistent rounding.

## Verification

✓ Calculated using standard WCAG 2.2 relative-luminance formula
✓ Verified with reproducible Node.js calculation  
✓ No CSS values or runtime behavior changed (documentation-only)
✓ All documented ratios verified against same formula
✓ Astro build: 0 errors, 0 warnings, 0 hints
✓ Prettier formatting: Pass

## Reviewers

Requires experience/accessibility review by: **Jadzia Dax**

---

**Note:** Exact-SHA approval required before merge per Squad workflow rules.