### PR TITLE
[Squad] Add zero-cost uptime and apex A-record monitor for jamula.net

### DIFF
--- a/.github/workflows/uptime-apex-monitor.yml
+++ b/.github/workflows/uptime-apex-monitor.yml
@@ -1,0 +1,95 @@
+name: Uptime and Apex A-Record Monitor
+
+on:
+  schedule:
+    # Every 15 minutes
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: uptime-apex-monitor
+  cancel-in-progress: true
+
+jobs:
+  check:
+    name: DNS and HTTPS health
+    runs-on: ubuntu-latest
+    steps:
+      - name: Resolve apex A record
+        id: dns
+        shell: bash
+        env:
+          APPROVED_IP: "48.192.33.154"
+        run: |
+          set -euo pipefail
+
+          resolved="$(
+            dig +short +time=5 +tries=2 A jamula.net | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$' | head -1
+          )"
+
+          if [[ -z "$resolved" ]]; then
+            echo "::error::jamula.net A record did not resolve."
+            exit 1
+          fi
+
+          echo "resolved_ip=${resolved}" >> "$GITHUB_OUTPUT"
+
+          if [[ "$resolved" != "$APPROVED_IP" ]]; then
+            echo "::error::jamula.net resolves to ${resolved} — expected approved Azure SWA IP ${APPROVED_IP}."
+            exit 1
+          fi
+
+          echo "DNS OK: jamula.net → ${resolved}"
+
+      - name: Fetch apex and verify canonical
+        id: https
+        shell: bash
+        run: |
+          set -euo pipefail
+
+          headers="$(mktemp)"
+          body="$(mktemp)"
+          trap 'rm -f "$headers" "$body"' EXIT
+
+          http_code="$(
+            curl \
+              --silent --show-error \
+              --proto '=https' --tlsv1.2 \
+              --max-time 15 \
+              --dump-header "$headers" \
+              --output "$body" \
+              --write-out '%{http_code}' \
+              "https://jamula.net/"
+          )"
+
+          if [[ "$http_code" != "200" ]]; then
+            echo "::error::https://jamula.net/ returned HTTP ${http_code} (expected 200)."
+            exit 1
+          fi
+
+          canonical="$(
+            grep -oi '<link[^>]*rel=["\x27]canonical["\x27][^>]*>' "$body" \
+            | grep -oi 'href=["\x27][^"'\'']*["\x27]' \
+            | grep -oi '"[^"]*"\|'\''[^'\'']*'\''' \
+            | tr -d '\"'\''
+          )"
+
+          if [[ "$canonical" != "https://jamula.net/" ]]; then
+            echo "::error::Canonical mismatch — got '${canonical}', expected 'https://jamula.net/'."
+            exit 1
+          fi
+
+          echo "HTTPS OK: HTTP 200, canonical=https://jamula.net/"
+
+      - name: Report success
+        if: success()
+        shell: bash
+        run: |
+          {
+            echo "### ✅ Apex monitor passed"
+            echo "- jamula.net A → \`${{ steps.dns.outputs.resolved_ip }}\`"
+            echo "- https://jamula.net/ → HTTP 200, canonical verified"
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Working as **Geordi La Forge (Full-Stack & Platform Engineer)**

Closes #52

## Summary

Adds `.github/workflows/uptime-apex-monitor.yml` — a zero-cost, scheduled GitHub Actions workflow that monitors jamula.net DNS and HTTPS health.

## What the monitor does

1. **DNS step** — Resolves `jamula.net` A record via `dig` and fails if it does not equal the approved Azure SWA inbound IP `48.192.33.154`.
2. **HTTPS step** — Fetches `https://jamula.net/`, requires HTTP 200, and verifies the HTML `<link rel="canonical">` is exactly `https://jamula.net/`.
3. **Summary step** — Appends a concise pass summary to the workflow step summary on success.

## Design decisions

- **Schedule**: every 15 minutes (`*/15 * * * *`) plus `workflow_dispatch` for manual runs.
- **Permissions**: `contents: read` only — least privilege, no secrets, no paid resources.
- **No automatic remediation** — the workflow reports failures; it does not act.
- **No TXT data enumerated** — DNS output filtered strictly to A records.
- **No new dependencies** — uses `dig` and `curl` already present on `ubuntu-latest`.
- **Concurrency**: `cancel-in-progress: true` prevents overlapping runs.

## Expected pre-cutover status

The apex currently resolves to legacy IP `3.65.42.183`. The DNS step will **intentionally fail** until issue #37 cuts over the apex A record to `48.192.33.154`. This distinguishes pre-cutover production state from workflow logic correctness.

## Exclusive-path compliance

Only `.github/workflows/uptime-apex-monitor.yml` is modified — within the approved exclusive paths.

## Reviewer notes

- **Miles O'Brien** — please review for reliability: retry strategy, timeout adequacy, failure message actionability, and any reliability edge cases.
- ⚠️ **Cyrus Jamula** — exact-SHA approval required before merge. Do not merge without Cyrus sign-off.

## Validation

- YAML syntax: ✅ valid
- Governance validation (`scripts/validate_governance.py`): ✅ passed
- Local DNS probe: apex resolves to `3.65.42.183` — pre-cutover failure expected ✅
- Local HTTPS probe: connection refused on `3.65.42.183:443` — confirms dead legacy IP ✅