### PR TITLE
[Squad] Replace apex monitor with .NET/C# implementation (issue #52)

### DIFF
--- a/.github/workflows/uptime-apex-monitor.yml
+++ b/.github/workflows/uptime-apex-monitor.yml
@@ -1,9 +1,27 @@
 name: Uptime and Apex A-Record Monitor
 
+# PRE-CUTOVER STATE: The schedule trigger is intentionally commented out.
+# This workflow must also remain disabled in repository Settings → Actions → Workflows
+# until the apex A-record cutover is complete.  Both guards together prevent
+# false-alarm failures while jamula.net still resolves to the legacy IP.
+#
+# GitHub's "disable workflow" flag is a repository setting independent of this YAML
+# file.  Merging this file to main does NOT silently re-enable the workflow; an
+# explicit enable action in the UI (or API) is still required.
+#
+# POST-CUTOVER procedure (issue #52 / #37):
+#   1. Perform the apex A-record change to 48.192.33.154.
+#   2. Open a PR that uncomments the schedule block below (one deliberate source
+#      change, reviewed and merged — no untracked silent re-enablement).
+#   3. In repository Settings → Actions → Workflows, click "Enable workflow"
+#      for this file.
+#   4. Trigger a manual run immediately via workflow_dispatch.
+#   5. Confirm the run is green; do not close issue #37 until it is.
+
 on:
-  schedule:
-    # Every 15 minutes
-    - cron: "*/15 * * * *"
+  # schedule:
+  #   # Every 15 minutes — uncomment in the post-cutover PR described above
+  #   - cron: "*/15 * * * *"
   workflow_dispatch:
 
 permissions:
@@ -17,79 +35,35 @@ jobs:
   check:
     name: DNS and HTTPS health
     runs-on: ubuntu-latest
+    # net8.0 LTS is pre-installed on ubuntu-latest (ubuntu-24.04); no setup-dotnet needed.
+    timeout-minutes: 5
     steps:
-      - name: Resolve apex A record
-        id: dns
-        shell: bash
-        env:
-          APPROVED_IP: "48.192.33.154"
-        run: |
-          set -euo pipefail
+      - name: Check out repository
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
 
-          resolved="$(
-            dig +short +time=5 +tries=2 A jamula.net | grep -E '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$' | head -1
-          )"
+      - name: Verify .NET SDK
+        run: dotnet --version
 
-          if [[ -z "$resolved" ]]; then
-            echo "::error::jamula.net A record did not resolve."
-            exit 1
-          fi
+      - name: Build monitor
+        run: dotnet build scripts/monitor/JamulaMonitor.csproj -c Release --nologo
 
-          echo "resolved_ip=${resolved}" >> "$GITHUB_OUTPUT"
+      - name: Run canonical-parser self-tests
+        run: >-
+          dotnet run --project scripts/monitor/JamulaMonitor.csproj
+          -c Release --no-build -- --self-test
 
-          if [[ "$resolved" != "$APPROVED_IP" ]]; then
-            echo "::error::jamula.net resolves to ${resolved} — expected approved Azure SWA IP ${APPROVED_IP}."
-            exit 1
-          fi
-
-          echo "DNS OK: jamula.net → ${resolved}"
-
-      - name: Fetch apex and verify canonical
-        id: https
-        shell: bash
-        run: |
-          set -euo pipefail
-
-          headers="$(mktemp)"
-          body="$(mktemp)"
-          trap 'rm -f "$headers" "$body"' EXIT
-
-          http_code="$(
-            curl \
-              --silent --show-error \
-              --proto '=https' --tlsv1.2 \
-              --max-time 15 \
-              --dump-header "$headers" \
-              --output "$body" \
-              --write-out '%{http_code}' \
-              "https://jamula.net/"
-          )"
-
-          if [[ "$http_code" != "200" ]]; then
-            echo "::error::https://jamula.net/ returned HTTP ${http_code} (expected 200)."
-            exit 1
-          fi
-
-          canonical="$(
-            grep -oi '<link[^>]*rel=["\x27]canonical["\x27][^>]*>' "$body" \
-            | grep -oi 'href=["\x27][^"'\'']*["\x27]' \
-            | grep -oi '"[^"]*"\|'\''[^'\'']*'\''' \
-            | tr -d '\"'\''
-          )"
-
-          if [[ "$canonical" != "https://jamula.net/" ]]; then
-            echo "::error::Canonical mismatch — got '${canonical}', expected 'https://jamula.net/'."
-            exit 1
-          fi
-
-          echo "HTTPS OK: HTTP 200, canonical=https://jamula.net/"
+      - name: Check DNS apex A record and HTTPS canonical
+        run: >-
+          dotnet run --project scripts/monitor/JamulaMonitor.csproj
+          -c Release --no-build
 
       - name: Report success
         if: success()
-        shell: bash
         run: |
           {
             echo "### ✅ Apex monitor passed"
-            echo "- jamula.net A → \`${{ steps.dns.outputs.resolved_ip }}\`"
-            echo "- https://jamula.net/ → HTTP 200, canonical verified"
+            echo "- \`jamula.net\` A record → approved Azure SWA IP verified"
+            echo "- \`https://jamula.net/\` → HTTP 200, canonical \`https://jamula.net/\` verified"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/scripts/monitor/JamulaMonitor.csproj
+++ b/scripts/monitor/JamulaMonitor.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <!-- net8.0 LTS — pre-installed on GitHub-hosted ubuntu-latest (ubuntu-24.04).
+         No actions/setup-dotnet required. Support window: through November 2026. -->
+    <TargetFramework>net8.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <AssemblyName>JamulaMonitor</AssemblyName>
+    <RootNamespace>JamulaMonitor</RootNamespace>
+  </PropertyGroup>
+  <!-- No third-party NuGet packages; BCL only. -->
+</Project>

--- a/scripts/monitor/Program.cs
+++ b/scripts/monitor/Program.cs
@@ -1,0 +1,300 @@
+// Jamula apex uptime and A-record drift monitor.
+//
+// Usage:
+//   JamulaMonitor              — run live DNS + HTTPS checks
+//   JamulaMonitor --self-test  — run offline canonical-parser self-tests
+//
+// Exit codes:
+//   0  All checks passed
+//   1  DNS: no IPv4 A record resolved for apex host
+//   2  DNS: A record mismatch — IP drift detected
+//   3  HTTPS: request failed or timed out
+//   4  HTTPS: non-200 status code
+//   5  Canonical: no <link rel="canonical"> tag in response HTML
+//   6  Canonical: tag found but href attribute is absent or empty
+//   7  Canonical: href value does not match expected canonical URL
+
+using System.Net;
+using System.Net.Sockets;
+using System.Text.RegularExpressions;
+
+// ── Entry point ───────────────────────────────────────────────────────────────
+
+if (args.Length > 0 && args[0] == "--self-test")
+    return SelfTests.Run();
+
+using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(28));
+try
+{
+    return await Monitor.RunAsync(cts.Token);
+}
+catch (OperationCanceledException)
+{
+    Console.Error.WriteLine("::error::Monitor timed out (28-second global budget exceeded).");
+    return 3;
+}
+
+// ── Configuration ─────────────────────────────────────────────────────────────
+
+static class Config
+{
+    public const string ApexHost = "jamula.net";
+    public const string ApprovedIp = "48.192.33.154"; // approved Azure Static Web Apps inbound IP
+    public const string ApexUrl = "https://jamula.net/";
+    public const string ExpectedCanonical = "https://jamula.net/";
+}
+
+// ── Result types ──────────────────────────────────────────────────────────────
+
+enum CanonicalResult
+{
+    Ok,
+    Absent,       // no <link rel="canonical"> tag found
+    MalformedHref // tag found but href attribute missing or empty
+}
+
+// ── Canonical extraction (pure, network-free, testable) ───────────────────────
+
+static class CanonicalParser
+{
+    // Matches any complete <link ...> or <link ... /> tag.
+    private static readonly Regex LinkTag =
+        new(@"<link\b[^>]*/?>", RegexOptions.IgnoreCase | RegexOptions.Singleline);
+
+    // Checks whether a tag carries rel="canonical" (single or double quotes, whitespace-tolerant).
+    private static readonly Regex RelCanonical =
+        new(@"\brel\s*=\s*([""'])canonical\1", RegexOptions.IgnoreCase);
+
+    // Extracts the href attribute value (single or double quotes, value captured in group 2).
+    private static readonly Regex HrefAttr =
+        new(@"\bhref\s*=\s*([""'])([^""']*)\1", RegexOptions.IgnoreCase);
+
+    /// <summary>
+    /// Extracts the canonical URL from the first &lt;link rel="canonical"&gt; tag in
+    /// <paramref name="html"/>.  Returns a discriminated result so callers can emit
+    /// precise diagnostics for each failure mode.
+    /// </summary>
+    public static (CanonicalResult Result, string? Href) Extract(string html)
+    {
+        var canonicalTag = LinkTag.Matches(html)
+            .Cast<Match>()
+            .FirstOrDefault(m => RelCanonical.IsMatch(m.Value));
+
+        if (canonicalTag is null)
+            return (CanonicalResult.Absent, null);
+
+        var hrefMatch = HrefAttr.Match(canonicalTag.Value);
+        if (!hrefMatch.Success || string.IsNullOrEmpty(hrefMatch.Groups[2].Value))
+            return (CanonicalResult.MalformedHref, null);
+
+        return (CanonicalResult.Ok, hrefMatch.Groups[2].Value);
+    }
+}
+
+// ── Monitor ───────────────────────────────────────────────────────────────────
+
+static class Monitor
+{
+    public static async Task<int> RunAsync(CancellationToken ct)
+    {
+        // ── DNS A-record check ─────────────────────────────────────────────
+        IPAddress[] addresses;
+        try
+        {
+            addresses = await Dns.GetHostAddressesAsync(
+                Config.ApexHost, AddressFamily.InterNetwork, ct);
+        }
+        catch (Exception ex)
+        {
+            Console.Error.WriteLine(
+                $"::error::DNS: resolution failed for {Config.ApexHost}: {ex.Message}");
+            return 1;
+        }
+
+        var ipv4 = addresses.FirstOrDefault(a => a.AddressFamily == AddressFamily.InterNetwork);
+        if (ipv4 is null)
+        {
+            Console.Error.WriteLine(
+                $"::error::DNS: {Config.ApexHost} returned no IPv4 A record (empty response).");
+            return 1;
+        }
+
+        string resolved = ipv4.ToString();
+        if (resolved != Config.ApprovedIp)
+        {
+            Console.Error.WriteLine(
+                $"::error::DNS drift: {Config.ApexHost} resolves to {resolved} — "
+                + $"expected approved Azure SWA IP {Config.ApprovedIp}.");
+            return 2;
+        }
+
+        Console.WriteLine($"DNS OK: {Config.ApexHost} → {resolved}");
+
+        // ── HTTPS check ────────────────────────────────────────────────────
+        HttpResponseMessage response;
+        string html;
+        try
+        {
+            using var handler = new HttpClientHandler
+            {
+                AllowAutoRedirect = true,
+                MaxAutomaticRedirections = 5
+            };
+            using var client = new HttpClient(handler)
+            {
+                Timeout = TimeSpan.FromSeconds(20)
+            };
+
+            response = await client.GetAsync(Config.ApexUrl, ct);
+            html = await response.Content.ReadAsStringAsync(ct);
+        }
+        catch (TaskCanceledException ex) when (!ct.IsCancellationRequested)
+        {
+            Console.Error.WriteLine(
+                $"::error::HTTPS: request to {Config.ApexUrl} timed out: {ex.Message}");
+            return 3;
+        }
+        catch (HttpRequestException ex)
+        {
+            Console.Error.WriteLine(
+                $"::error::HTTPS: request to {Config.ApexUrl} failed: {ex.Message}");
+            return 3;
+        }
+
+        int statusCode = (int)response.StatusCode;
+        if (statusCode != 200)
+        {
+            Console.Error.WriteLine(
+                $"::error::HTTPS: {Config.ApexUrl} returned HTTP {statusCode} "
+                + $"{response.ReasonPhrase} — expected 200.");
+            return 4;
+        }
+
+        Console.WriteLine($"HTTPS OK: {Config.ApexUrl} → HTTP {statusCode}");
+
+        // ── Canonical check ────────────────────────────────────────────────
+        var (result, href) = CanonicalParser.Extract(html);
+        switch (result)
+        {
+            case CanonicalResult.Absent:
+                Console.Error.WriteLine(
+                    $"::error::Canonical: no <link rel=\"canonical\"> tag found in "
+                    + $"{Config.ApexUrl} response HTML.");
+                return 5;
+
+            case CanonicalResult.MalformedHref:
+                Console.Error.WriteLine(
+                    $"::error::Canonical: <link rel=\"canonical\"> found but href attribute "
+                    + $"is absent or empty in {Config.ApexUrl} response HTML.");
+                return 6;
+
+            default:
+                if (href != Config.ExpectedCanonical)
+                {
+                    Console.Error.WriteLine(
+                        $"::error::Canonical mismatch: got '{href}', "
+                        + $"expected '{Config.ExpectedCanonical}'.");
+                    return 7;
+                }
+                Console.WriteLine($"Canonical OK: {href}");
+                break;
+        }
+
+        Console.WriteLine("All checks passed.");
+        return 0;
+    }
+}
+
+// ── Self-tests (offline, covers all CanonicalParser paths) ────────────────────
+
+static class SelfTests
+{
+    public static int Run()
+    {
+        int failures = 0;
+
+        void Assert(string name, bool condition)
+        {
+            if (condition)
+                Console.WriteLine($"PASS: {name}");
+            else
+            {
+                Console.Error.WriteLine($"FAIL: {name}");
+                failures++;
+            }
+        }
+
+        // 1. Valid canonical — double quotes, standard attribute order
+        {
+            const string html = """
+                <html><head>
+                <link rel="canonical" href="https://jamula.net/">
+                </head></html>
+                """;
+            var (r, h) = CanonicalParser.Extract(html);
+            Assert("Valid canonical — result is Ok", r == CanonicalResult.Ok);
+            Assert("Valid canonical — href matches expected", h == Config.ExpectedCanonical);
+        }
+
+        // 2. Absent canonical — no link tag at all
+        {
+            const string html = """
+                <html><head><meta charset="utf-8"></head><body></body></html>
+                """;
+            var (r, _) = CanonicalParser.Extract(html);
+            Assert("Absent canonical — result is Absent", r == CanonicalResult.Absent);
+        }
+
+        // 3. Malformed: rel="canonical" tag present but no href attribute
+        {
+            const string html = """
+                <html><head><link rel="canonical"></head></html>
+                """;
+            var (r, _) = CanonicalParser.Extract(html);
+            Assert("Malformed canonical (no href) — result is MalformedHref",
+                r == CanonicalResult.MalformedHref);
+        }
+
+        // 4. Canonical mismatch — www prefix present (wrong value)
+        {
+            const string html = """
+                <html><head>
+                <link rel="canonical" href="https://www.jamula.net/">
+                </head></html>
+                """;
+            var (r, h) = CanonicalParser.Extract(html);
+            Assert("Mismatch canonical — result is Ok (href captured)", r == CanonicalResult.Ok);
+            Assert("Mismatch canonical — href is NOT the expected value",
+                h != Config.ExpectedCanonical);
+            Assert("Mismatch canonical — href is the www variant",
+                h == "https://www.jamula.net/");
+        }
+
+        // 5. Single-quoted attributes
+        {
+            const string html =
+                "<html><head><link rel='canonical' href='https://jamula.net/'></head></html>";
+            var (r, h) = CanonicalParser.Extract(html);
+            Assert("Single-quoted canonical — result is Ok", r == CanonicalResult.Ok);
+            Assert("Single-quoted canonical — href matches", h == Config.ExpectedCanonical);
+        }
+
+        // 6. Reversed attribute order (href before rel)
+        {
+            const string html = """
+                <html><head>
+                <link href="https://jamula.net/" rel="canonical">
+                </head></html>
+                """;
+            var (r, h) = CanonicalParser.Extract(html);
+            Assert("Reversed attributes — result is Ok", r == CanonicalResult.Ok);
+            Assert("Reversed attributes — href matches", h == Config.ExpectedCanonical);
+        }
+
+        Console.WriteLine(failures == 0
+            ? "\nAll 6 self-tests passed."
+            : $"\n{failures} self-test(s) FAILED.");
+
+        return failures == 0 ? 0 : 1;
+    }
+}


### PR DESCRIPTION
Working as **Jean-Luc Picard (Product & Architecture Lead)** on an independent reviewer-mandated revision.

**Locked-out authors (non-participants in this cycle):**
- Geordi La Forge — authored rejected PR #53 (bash-only, no timeout, fragile canonical grep)
- @copilot — authored rejected PR #54 (Python canonical parser, violates .NET-only policy)

This revision was authored independently without consulting or pairing with either locked-out author.

Closes #52

---

## What changed

| Path | Change |
|------|--------|
| `.github/workflows/uptime-apex-monitor.yml` | Full replacement — .NET orchestration, `timeout-minutes: 5`, schedule pre-cutover commented out |
| `scripts/monitor/JamulaMonitor.csproj` | New — dependency-free .NET 8 console project (BCL only, no NuGet packages) |
| `scripts/monitor/Program.cs` | New — end-to-end monitor + offline self-test mode |

No other paths changed. Exclusive-path compliance verified against diff.

---

## .NET SDK / target framework selection

- **Target:** `net8.0` (LTS, supported through November 2026)
- **Evidence:** GitHub-hosted ubuntu-latest (ubuntu-24.04) pre-installs .NET 8 SDK; verified at https://github.com/actions/runner-images
- **`actions/setup-dotnet`:** Not used — .NET 8 SDK is pre-installed, so it is not needed per issue requirement
- **Action pins:** `actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4` — consistent with `governance-validation.yml` and `required-pr-validation.yml` conventions

---

## Monitor behaviour

The .NET console tool (`JamulaMonitor`) performs three sequential checks with a 28-second global cancellation budget (job timeout-minutes: 5 provides the outer bound):

### 1. DNS A-record check
Resolves `jamula.net` IPv4 A record via `System.Net.Dns.GetHostAddressesAsync` (BCL, .NET 6+). Fails with distinct exit codes and `::error::` diagnostics for:
- **Exit 1** — DNS resolution failed or returned no IPv4 address (empty response)
- **Exit 2** — resolved IP does not match approved Azure SWA IP `48.192.33.154` (drift)

### 2. HTTPS check
`HttpClient` GET to `https://jamula.net/` with a 20-second inner timeout plus the global cancellation token. Fails with:
- **Exit 3** — request timed out or TCP/TLS failure
- **Exit 4** — HTTP status code ≠ 200

### 3. Canonical check
BCL `Regex` extracts the first `<link rel="canonical">` tag. Handles arbitrary attribute order, single and double quotes. Fails with:
- **Exit 5** — no `<link rel="canonical">` tag in response HTML
- **Exit 6** — tag present but `href` attribute absent or empty (malformed tag)
- **Exit 7** — `href` value does not exactly equal `https://jamula.net/` (mismatch)

---

## Self-tests

`JamulaMonitor --self-test` exercises all `CanonicalParser` paths offline (no network):

| # | Case | Expected |
|---|------|----------|
| 1 | Valid canonical, double quotes | `Ok`, href = `https://jamula.net/` |
| 2 | No canonical tag in HTML | `Absent` |
| 3 | Tag present, no href attribute | `MalformedHref` |
| 4 | Canonical with www prefix | `Ok`, href ≠ expected (mismatch detected by caller) |
| 5 | Single-quoted attributes | `Ok`, href = `https://jamula.net/` |
| 6 | Reversed attribute order (href before rel) | `Ok`, href = `https://jamula.net/` |

All 11 assertions passed locally (`dotnet run … -- --self-test` exit 0).

---

## Pre-cutover status

**This monitor is expected to FAIL on a live run today** — `jamula.net` still resolves to the legacy IP, not `48.192.33.154`. That is intentional and correct. The self-test step will always pass (offline); the DNS/HTTPS monitor step will fail on the legacy IP. Do not interpret a failed live run as a defect.

The workflow is disabled in repository Settings → Actions → Workflows and will remain so until Cyrus authorises the apex A-record change.

---

## Enabling after cutover (no untracked code change)

The schedule trigger is commented out in the YAML. GitHub's "disable workflow" flag is stored as a repository setting independent of the YAML content; merging this file does **not** silently re-enable it.

**Post-cutover steps:**
1. Perform the apex A-record change to `48.192.33.154`.
2. Open a PR that uncomments the `schedule:` block (a deliberate, reviewed source change).
3. In repository Settings → Actions → Workflows, click **Enable workflow**.
4. Trigger a manual `workflow_dispatch` run immediately.
5. Confirm green. Do not close issue #37 until the run is green.

---

## Review requirements

- **Miles O'Brien** — exact-SHA re-review at commit `0dab6f779365c7c2bb24926051b460016039644b`
- **Cyrus Jamula** — exact-SHA approval required before merge

Do not merge, enable the workflow, change DNS/Azure settings, or hand-edit mutable Squad state as part of this PR.