### PR TITLE
CI: validate server builds and update dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,29 @@
 
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: "github-actions"
+    directory: "/"
     schedule:
-      interval: "weekly" 
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "npm"
+    directory: "/www"
+    schedule:
+      interval: "weekly"
+    groups:
+      npm-dependencies:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "nuget"
+    directory: "/scripts/monitor"
+    schedule:
+      interval: "weekly"
+    groups:
+      nuget-dependencies:
+        patterns:
+          - "*"

--- a/.github/workflows/required-pr-validation.yml
+++ b/.github/workflows/required-pr-validation.yml
@@ -32,13 +32,21 @@ jobs:
           BASE_SHA: ${{ github.event.pull_request.base.sha }}
           HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
-          changed_files="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- ':(top)www/')"
-          if [[ -n "$changed_files" ]]; then
+          website_files="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- ':(top)www/')"
+          monitor_files="$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- ':(top)scripts/monitor/')"
+          if [[ -n "$website_files" ]]; then
             echo "website=true" >> "$GITHUB_OUTPUT"
             echo "Website validation required."
           else
             echo "website=false" >> "$GITHUB_OUTPUT"
             echo "No website changes; npm validation is not required."
+          fi
+          if [[ -n "$monitor_files" ]]; then
+            echo "monitor=true" >> "$GITHUB_OUTPUT"
+            echo "Monitor validation required."
+          else
+            echo "monitor=false" >> "$GITHUB_OUTPUT"
+            echo "No monitor changes; .NET validation is not required."
           fi
 
       - name: Set up Node.js
@@ -81,3 +89,18 @@ jobs:
       - name: Build static website
         if: steps.changes.outputs.website == 'true'
         run: npm exec -- astro build
+
+      - name: Verify .NET SDK
+        if: steps.changes.outputs.monitor == 'true'
+        working-directory: scripts/monitor
+        run: dotnet --version
+
+      - name: Build monitor
+        if: steps.changes.outputs.monitor == 'true'
+        working-directory: scripts/monitor
+        run: dotnet build JamulaMonitor.csproj --configuration Release --nologo
+
+      - name: Run monitor self-tests
+        if: steps.changes.outputs.monitor == 'true'
+        working-directory: scripts/monitor
+        run: dotnet run --project JamulaMonitor.csproj --configuration Release --no-build -- --self-test

--- a/.github/workflows/squad-ci.yml
+++ b/.github/workflows/squad-ci.yml
@@ -1,5 +1,4 @@
 name: Squad CI
-# Project type was not detected — configure build/test commands below
 
 on:
   pull_request:
@@ -15,14 +14,34 @@ jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
-      - name: Build and test
-        run: |
-          # TODO: Project type was not detected — add your build/test commands here
-          # Go:            go test ./...
-          # Python:        pip install -r requirements.txt && pytest
-          # .NET:          dotnet test
-          # Java (Maven):  mvn test
-          # Java (Gradle): ./gradlew test
-          echo "No build commands configured — update squad-ci.yml"
+      - name: Set up Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+        with:
+          node-version: 24.15.0
+          cache: npm
+          cache-dependency-path: www/package-lock.json
+
+      - name: Install npm 12
+        run: npm install --global npm@12.0.2
+
+      - name: Install website dependencies
+        working-directory: www
+        run: npm ci
+
+      - name: Check website
+        working-directory: www
+        run: npm run check
+
+      - name: Build website
+        working-directory: www
+        run: npm run build
+
+      - name: Build monitor
+        working-directory: scripts/monitor
+        run: dotnet build JamulaMonitor.csproj --configuration Release --nologo
+
+      - name: Run monitor self-tests
+        working-directory: scripts/monitor
+        run: dotnet run --project JamulaMonitor.csproj --configuration Release --no-build -- --self-test

--- a/www/package-lock.json
+++ b/www/package-lock.json
@@ -8,8 +8,8 @@
       "name": "jamula-www",
       "version": "0.1.0",
       "dependencies": {
-        "@astrojs/sitemap": "^3.7.3",
-        "astro": "^7.2.9"
+        "@astrojs/sitemap": "^3.7.4",
+        "astro": "^7.3.1"
       },
       "devDependencies": {
         "@astrojs/check": "^0.9.10",
@@ -238,9 +238,9 @@
       }
     },
     "node_modules/@astrojs/internal-helpers": {
-      "version": "0.10.4",
-      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.10.4.tgz",
-      "integrity": "sha512-nozZSy/mKYLqe4YrqbKtdOszedAfXYCtw3wZ0d+CAjz4GqQ4L9rl1ltIL5BlgwmYVinJg/RZ0MgGuWOdlyRZlA==",
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/internal-helpers/-/internal-helpers-0.11.0.tgz",
+      "integrity": "sha512-3rzxJ+xbo0+8YyqOzLziIN32wmsHdCjEVz2sGOpRxJ+Ben/KiLph4ItxBy1abEL+E8fkRzqjg0rfXmaHJGw9JA==",
       "license": "MIT",
       "dependencies": {
         "@types/hast": "^3.0.4",
@@ -296,12 +296,12 @@
       }
     },
     "node_modules/@astrojs/markdown-satteri": {
-      "version": "0.3.8",
-      "resolved": "https://registry.npmjs.org/@astrojs/markdown-satteri/-/markdown-satteri-0.3.8.tgz",
-      "integrity": "sha512-n8ItpFTCmlDsVR5+rwDmehSf+jFCYLWmZiisZNGuF7xILqYhsVeBfcha4qgS2Seq3fAc9Tm58ZVrvqFQ6RQgRQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@astrojs/markdown-satteri/-/markdown-satteri-0.4.0.tgz",
+      "integrity": "sha512-wykOOW9KsUVcZweOpY/CeXpdKcCKZy6fQbdcteWFuI75+sQCiqxYM7VKsGa5b+aGl3cYQscFY37rsbbyal5MRw==",
       "license": "MIT",
       "dependencies": {
-        "@astrojs/internal-helpers": "0.10.4",
+        "@astrojs/internal-helpers": "0.11.0",
         "@astrojs/prism": "4.0.2",
         "github-slugger": "^2.0.0",
         "satteri": "^0.10.3"
@@ -320,13 +320,12 @@
       }
     },
     "node_modules/@astrojs/sitemap": {
-      "version": "3.7.3",
-      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.7.3.tgz",
-      "integrity": "sha512-f8euLVsyeAmAkSm/1M2Kb8sL8byQmfgbvBNaHFItCheTj/IpiJYSEWVcqDHZ/yEHxiS7+w87mQkzwZaPHmk5GA==",
+      "version": "3.7.4",
+      "resolved": "https://registry.npmjs.org/@astrojs/sitemap/-/sitemap-3.7.4.tgz",
+      "integrity": "sha512-LbKNC24bdUWcQf/pThB6qLlSqHojxGjZDURIzFocY8rlWnAn2t74nnhnK6S5x0NHriHoAduLEpVjRykmeGiVvA==",
       "license": "MIT",
       "dependencies": {
         "sitemap": "^9.0.0",
-        "stream-replace-string": "^2.0.0",
         "zod": "^4.3.6"
       }
     },
@@ -2777,14 +2776,14 @@
       }
     },
     "node_modules/astro": {
-      "version": "7.2.9",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-7.2.9.tgz",
-      "integrity": "sha512-o5nZFo/bieF6rp4x9sQSLhI7GO7Bahpld38Y4LvX27nFoxNiuttjI+Hea81w5ksORLHgdPUlQpU9obPz5QRa8g==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-7.3.1.tgz",
+      "integrity": "sha512-A/bJYHtc6n0UAdROY9W948fW6lX0pnUA+JWKW+IGCXRyDIGN2MsXC0OlS8onZGJjr+sv8htemwOc9W5PBRXCkw==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/compiler-rs": "^0.4.0",
-        "@astrojs/internal-helpers": "0.10.4",
-        "@astrojs/markdown-satteri": "0.3.8",
+        "@astrojs/internal-helpers": "0.11.0",
+        "@astrojs/markdown-satteri": "0.4.0",
         "@astrojs/telemetry": "3.3.3",
         "@capsizecss/unpack": "^4.0.0",
         "@clack/prompts": "^1.1.0",
@@ -2834,7 +2833,7 @@
         "vitefu": "^1.1.2",
         "xxhash-wasm": "^1.1.0",
         "yargs-parser": "^22.0.0",
-        "zod": "^4.3.6"
+        "zod": "^4.5.4"
       },
       "bin": {
         "astro": "bin/astro.mjs"
@@ -2852,7 +2851,7 @@
         "sharp": "^0.35.4"
       },
       "peerDependencies": {
-        "@astrojs/markdown-remark": "7.2.4"
+        "@astrojs/markdown-remark": "^7.3.0"
       },
       "peerDependenciesMeta": {
         "@astrojs/markdown-remark": {
@@ -4676,12 +4675,6 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
-    "node_modules/stream-replace-string": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/stream-replace-string/-/stream-replace-string-2.0.0.tgz",
-      "integrity": "sha512-TlnjJ1C0QrmxRNrON00JvaFFlNh5TTG00APw23j74ET7gkQpTASi6/L2fuiav8pzK715HXtUeClpBTw2NPSn6w==",
-      "license": "MIT"
-    },
     "node_modules/string-width": {
       "version": "8.2.2",
       "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
@@ -5679,9 +5672,9 @@
       }
     },
     "node_modules/zod": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.2.tgz",
-      "integrity": "sha512-XkYXCol10+ba/6F/cueWV+TezUeOqXW0hdeJt5CdXjTYeAgAQg5N03RQdJ80mhfFE72+pblvYMW4wy2Qp4Qbrg==",
+      "version": "4.5.4",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.5.4.tgz",
+      "integrity": "sha512-sC95tT5iHHH9gtpj6A81kh+NEaRAUFN+qlUPDUbRfOMvNf5QCBqsb3WgvnpVtK5Y+4UfA6KqufotuTvMGiTlsA==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/www/package.json
+++ b/www/package.json
@@ -16,8 +16,8 @@
     "format:check": "prettier --check ."
   },
   "dependencies": {
-    "@astrojs/sitemap": "^3.7.3",
-    "astro": "^7.2.9"
+    "@astrojs/sitemap": "^3.7.4",
+    "astro": "^7.3.1"
   },
   "devDependencies": {
     "@astrojs/check": "^0.9.10",


### PR DESCRIPTION
## Why

The repository had placeholder CI steps and an invalid Dependabot ecosystem entry, while website dependencies had newer compatible releases. This left server regressions and dependency drift outside automated validation.

## Approach

- Configure Dependabot for GitHub Actions, npm in `www/`, and NuGet in `scripts/monitor/`, grouping updates by ecosystem.
- Upgrade Astro and `@astrojs/sitemap` and regenerate the npm lockfile.
- Replace placeholder Squad CI steps with Node, Astro, monitor build, and monitor self-test commands.
- Extend required PR validation to detect and validate monitor changes in addition to website changes.

## Scope

Included:
- Dependabot configuration for all repository dependency ecosystems.
- Website dependency refresh and lockfile update.
- Website and .NET monitor CI validation.

Non-goals:
- No application feature or content changes.
- No changes to the live uptime/DNS check behavior.

## Tracking

Refs N/A

## Evidence and validation

- `npm ci`, `npm run check`, and `npm run build` pass in `www/`.
- `dotnet build scripts/monitor/JamulaMonitor.csproj --configuration Release` passes.
- The monitor offline self-test passes all 7 cases.
- Changed YAML parses successfully and the final diff has no whitespace errors.

## Privacy, security, accessibility, legal, environmental, and social review

No new data handling, public claims, accessibility behavior, legal terms, or environmental impact were introduced. Existing pinned action revisions were preserved.

## Licensing and provenance

No new third-party source content was added. npm package metadata and integrity values were generated from the configured npm registry.

## Branch, deployment, and cleanup

The branch is rebased onto `main` and pushed for PR validation. CI remains the deployment gate; no deployment configuration or production resources were changed.

## Approval

Pending Cyrus approval of the exact head SHA.