### PR TITLE
Fix governance validation workflow drift

### DIFF
--- a/.github/workflows/squad-heartbeat.yml
+++ b/.github/workflows/squad-heartbeat.yml
@@ -1,164 +1,46 @@
 name: Squad Heartbeat (Ralph)
-# ⚠️ SYNC: This workflow is maintained in 4 locations. Changes must be applied to all:
-#   - templates/workflows/squad-heartbeat.yml (source template)
-#   - packages/squad-cli/templates/workflows/squad-heartbeat.yml (CLI package)
-#   - .squad/templates/workflows/squad-heartbeat.yml (installed template)
-#   - .github/workflows/squad-heartbeat.yml (active workflow)
-# Run 'squad upgrade' to sync installed copies from source templates.
 
 on:
-  # React to completed work or new squad work
   issues:
-    types: [closed, labeled]
+    types: [closed]
   pull_request:
     types: [closed]
-
-  # Manual trigger
   workflow_dispatch:
 
 permissions:
-  issues: write
   contents: read
+  issues: read
   pull-requests: read
 
 jobs:
-  heartbeat:
+  monitor:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
-
-      - name: Check triage script
-        id: check-script
-        run: |
-          if [ -f ".squad/templates/ralph-triage.js" ]; then
-            echo "has_script=true" >> "$GITHUB_OUTPUT"
-          else
-            echo "has_script=false" >> "$GITHUB_OUTPUT"
-            echo "⚠️ ralph-triage.js not found — run 'squad upgrade' to install"
-          fi
-
-      - name: Ralph — Smart triage
-        if: steps.check-script.outputs.has_script == 'true'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          node .squad/templates/ralph-triage.js \
-            --squad-dir .squad \
-            --output triage-results.json
-
-      - name: Ralph — Apply triage decisions
-        if: steps.check-script.outputs.has_script == 'true' && hashFiles('triage-results.json') != ''
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #v7
+      - name: Report untriaged Squad work
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
         with:
           script: |
-            const fs = require('fs');
-            const path = 'triage-results.json';
-            if (!fs.existsSync(path)) {
-              core.info('No triage results — board is clear');
-              return;
-            }
-            
-            const results = JSON.parse(fs.readFileSync(path, 'utf8'));
-            if (results.length === 0) {
-              core.info('📋 Board is clear — Ralph found no untriaged issues');
-              return;
-            }
-            
-            for (const decision of results) {
-              try {
-                await github.rest.issues.addLabels({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: decision.issueNumber,
-                  labels: [decision.label]
-                });
-                
-                await github.rest.issues.createComment({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: decision.issueNumber,
-                  body: [
-                    '### 🔄 Ralph — Auto-Triage',
-                    '',
-                    `**Assigned to:** ${decision.assignTo}`,
-                    `**Reason:** ${decision.reason}`,
-                    `**Source:** ${decision.source}`,
-                    '',
-                    '> Ralph auto-triaged this issue using routing rules.',
-                    '> To reassign, swap the `squad:*` label.'
-                  ].join('\n')
-                });
-                
-                core.info(`Triaged #${decision.issueNumber} → ${decision.assignTo} (${decision.source})`);
-              } catch (e) {
-                core.warning(`Failed to triage #${decision.issueNumber}: ${e.message}`);
-              }
-            }
-            
-            core.info(`🔄 Ralph triaged ${results.length} issue(s)`);
+            const { data: issues } = await github.rest.issues.listForRepo({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: 'squad',
+              state: 'open',
+              per_page: 100,
+            });
 
-      # Copilot auto-assign step (uses PAT if available)
-      - name: Ralph — Assign @copilot issues
-        if: success()
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #v7
-        with:
-          github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN || secrets.GITHUB_TOKEN }}
-          script: |
-            const fs = require('fs');
-
-            const teamFile = '.squad/team.md';
-            if (!fs.existsSync(teamFile)) return;
-
-            const content = fs.readFileSync(teamFile, 'utf8');
-
-            // Check if @copilot is on the team with auto-assign
-            const hasCopilot = content.includes('🤖 Coding Agent') || content.includes('@copilot');
-            const autoAssign = content.includes('<!-- copilot-auto-assign: true -->');
-            if (!hasCopilot || !autoAssign) return;
-
-            // Find issues labeled squad:copilot with no assignee
-            try {
-              const { data: copilotIssues } = await github.rest.issues.listForRepo({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                labels: 'squad:copilot',
-                state: 'open',
-                per_page: 5
-              });
-
-              const unassigned = copilotIssues.filter(i =>
-                !i.assignees || i.assignees.length === 0
+            const untriaged = issues.filter(issue => {
+              const labels = issue.labels.map(label =>
+                typeof label === 'string' ? label : label.name
               );
+              return !labels.some(label => label && label.startsWith('squad:'));
+            });
 
-              if (unassigned.length === 0) {
-                core.info('No unassigned squad:copilot issues');
-                return;
-              }
-
-              // Get repo default branch
-              const { data: repoData } = await github.rest.repos.get({
-                owner: context.repo.owner,
-                repo: context.repo.repo
-              });
-
-              for (const issue of unassigned) {
-                try {
-                  await github.request('POST /repos/{owner}/{repo}/issues/{issue_number}/assignees', {
-                    owner: context.repo.owner,
-                    repo: context.repo.repo,
-                    issue_number: issue.number,
-                    assignees: ['copilot-swe-agent[bot]'],
-                    agent_assignment: {
-                      target_repo: `${context.repo.owner}/${context.repo.repo}`,
-                      base_branch: repoData.default_branch,
-                      custom_instructions: `Read .squad/team.md for team context and .squad/routing.md for routing rules.`
-                    }
-                  });
-                  core.info(`Assigned copilot-swe-agent[bot] to #${issue.number}`);
-                } catch (e) {
-                  core.warning(`Failed to assign @copilot to #${issue.number}: ${e.message}`);
-                }
-              }
-            } catch (e) {
-              core.info(`No squad:copilot label found or error: ${e.message}`);
+            if (untriaged.length === 0) {
+              core.info('Ralph: no untriaged Squad issues.');
+              return;
             }
+
+            core.warning(
+              `Ralph: ${untriaged.length} issue(s) await the authoritative Squad Triage workflow: ` +
+              untriaged.map(issue => `#${issue.number}`).join(', ')
+            );

--- a/.github/workflows/squad-issue-assign.yml
+++ b/.github/workflows/squad-issue-assign.yml
@@ -16,6 +16,16 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
 
+      - name: Read Copilot auto-assignment policy
+        id: copilot_policy
+        shell: bash
+        run: |
+          if grep -q '<!-- copilot-auto-assign: true -->' .squad/team.md; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Identify assigned member and trigger work
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #v7
         with:
@@ -35,6 +45,8 @@ jobs:
 
             const content = fs.readFileSync(teamFile, 'utf8');
             const lines = content.split('\n');
+            const copilotAutoAssign = content.includes('<!-- copilot-auto-assign: true -->');
+            const slugify = (value) => value.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, '');
 
             // Check if this is a coding agent assignment
             const isCopilotAssignment = memberName === 'copilot';
@@ -54,7 +66,7 @@ jobs:
                 }
                 if (inMembersTable && line.startsWith('|') && !line.includes('---') && !line.includes('Name')) {
                   const cells = line.split('|').map(c => c.trim()).filter(Boolean);
-                  if (cells.length >= 2 && cells[0].toLowerCase() === memberName) {
+                  if (cells.length >= 2 && slugify(cells[0]) === memberName) {
                     assignedMember = { name: cells[0], role: cells[1] };
                     break;
                   }
@@ -76,16 +88,25 @@ jobs:
             // Post assignment acknowledgment
             let comment;
             if (isCopilotAssignment) {
-              comment = [
-                `### 🤖 Routed to @copilot (Coding Agent)`,
-                '',
-                `**Issue:** #${issue.number} — ${issue.title}`,
-                '',
-                `@copilot has been assigned and will pick this up automatically.`,
-                '',
-                `> The coding agent will create a \`copilot/*\` branch and open a draft PR.`,
-                `> Review the PR as you would any team member's work.`,
-              ].join('\n');
+              comment = copilotAutoAssign
+                ? [
+                    `### 🤖 Routed to @copilot (Coding Agent)`,
+                    '',
+                    `**Issue:** #${issue.number} — ${issue.title}`,
+                    '',
+                    `@copilot has been assigned and will pick this up automatically.`,
+                    '',
+                    `> The coding agent will create a \`copilot/*\` branch and open a draft PR.`,
+                    `> Review the PR as you would any team member's work.`,
+                  ].join('\n')
+                : [
+                    `### 📋 Copilot route recorded`,
+                    '',
+                    `**Issue:** #${issue.number} — ${issue.title}`,
+                    '',
+                    `Automatic Copilot assignment is disabled in \`.squad/team.md\`.`,
+                    `Cyrus must approve enabling it before work can start automatically.`,
+                  ].join('\n');
             } else {
               comment = [
                 `### 📋 Assigned to ${assignedMember.name} (${assignedMember.role})`,
@@ -111,7 +132,7 @@ jobs:
 
       # Separate step: assign @copilot using PAT (required for coding agent)
       - name: Assign @copilot coding agent
-        if: github.event.label.name == 'squad:copilot'
+        if: github.event.label.name == 'squad:copilot' && steps.copilot_policy.outputs.enabled == 'true'
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #v7
         with:
           github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN }}

--- a/.github/workflows/squad-triage.yml
+++ b/.github/workflows/squad-triage.yml
@@ -15,7 +15,18 @@ jobs:
     steps:
       - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
 
+      - name: Read Copilot auto-assignment policy
+        id: copilot_policy
+        shell: bash
+        run: |
+          if grep -q '<!-- copilot-auto-assign: true -->' .squad/team.md; then
+            echo "enabled=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "enabled=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Triage issue via Lead agent
+        id: triage_issue
         uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #v7
         with:
           script: |
@@ -42,9 +53,9 @@ jobs:
 
             if (hasCopilot) {
               // Extract capability tiers from team.md
-              const goodFitMatch = content.match(/🟢\s*Good fit[^:]*:\s*(.+)/i);
-              const needsReviewMatch = content.match(/🟡\s*Needs review[^:]*:\s*(.+)/i);
-              const notSuitableMatch = content.match(/🔴\s*Not suitable[^:]*:\s*(.+)/i);
+              const goodFitMatch = content.match(/<!--\s*copilot-good-fit:\s*([^>]+)-->/i);
+              const needsReviewMatch = content.match(/<!--\s*copilot-needs-review:\s*([^>]+)-->/i);
+              const notSuitableMatch = content.match(/<!--\s*copilot-not-suitable:\s*([^>]+)-->/i);
 
               if (goodFitMatch) {
                 goodFitKeywords = goodFitMatch[1].toLowerCase().split(',').map(s => s.trim());
@@ -84,12 +95,6 @@ jobs:
               }
             }
 
-            const routingFile = '.squad/routing.md';
-            let routingContent = '';
-            if (fs.existsSync(routingFile)) {
-              routingContent = fs.readFileSync(routingFile, 'utf8');
-            }
-
             // Find the Lead
             const lead = members.find(m =>
               m.role.toLowerCase().includes('lead') ||
@@ -104,6 +109,15 @@ jobs:
 
             function slugify(t) { return t.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-|-$/g, ''); }
 
+            const routingFile = '.squad/routing.md';
+            const routeKeywords = {};
+            if (fs.existsSync(routingFile)) {
+              const routingContent = fs.readFileSync(routingFile, 'utf8');
+              for (const match of routingContent.matchAll(/<!--\s*route:([a-z0-9-]+)=([^>]+)-->/gi)) {
+                routeKeywords[match[1]] = match[2].split(',').map(keyword => keyword.trim().toLowerCase());
+              }
+            }
+
             // Build triage context
             const memberList = members.map(m =>
               `- **${m.name}** (${m.role}) → label: \`squad:${slugify(m.name)}\``
@@ -117,7 +131,7 @@ jobs:
             let copilotTier = null;
 
             // First, evaluate @copilot fit if enabled
-            if (hasCopilot) {
+            if (hasCopilot && copilotAutoAssign) {
               const isNotSuitable = notSuitableKeywords.some(kw => issueText.includes(kw));
               const isGoodFit = !isNotSuitable && goodFitKeywords.some(kw => issueText.includes(kw));
               const isNeedsReview = !isNotSuitable && !isGoodFit && needsReviewKeywords.some(kw => issueText.includes(kw));
@@ -138,41 +152,25 @@ jobs:
 
             // If not routed to @copilot, use keyword-based routing
             if (!assignedMember) {
+              const keywordMatches = (text, keyword) => {
+                const escaped = keyword.replace(/[.*+?^${}()|[\]\\]/g, '\\$&').replace(/\s+/g, '\\s+');
+                return new RegExp(`(^|[^a-z0-9])${escaped}([^a-z0-9]|$)`, 'i').test(text);
+              };
+              let bestRoute = null;
+
               for (const member of members) {
-                const role = member.role.toLowerCase();
-                if ((role.includes('frontend') || role.includes('ui')) &&
-                    (issueText.includes('ui') || issueText.includes('frontend') ||
-                     issueText.includes('css') || issueText.includes('component') ||
-                     issueText.includes('button') || issueText.includes('page') ||
-                     issueText.includes('layout') || issueText.includes('design'))) {
-                  assignedMember = member;
-                  triageReason = 'Issue relates to frontend/UI work';
-                  break;
+                const memberSlug = slugify(member.name);
+                const keywords = routeKeywords[memberSlug] || [];
+                const matches = keywords.filter(keyword => keywordMatches(issueText, keyword));
+                const score = matches.reduce((total, keyword) => total + keyword.length, 0);
+                if (score > 0 && (!bestRoute || score > bestRoute.score)) {
+                  bestRoute = { member, matches, score };
                 }
-                if ((role.includes('backend') || role.includes('api') || role.includes('server')) &&
-                    (issueText.includes('api') || issueText.includes('backend') ||
-                     issueText.includes('database') || issueText.includes('endpoint') ||
-                     issueText.includes('server') || issueText.includes('auth'))) {
-                  assignedMember = member;
-                  triageReason = 'Issue relates to backend/API work';
-                  break;
-                }
-                if ((role.includes('test') || role.includes('qa') || role.includes('quality')) &&
-                    (issueText.includes('test') || issueText.includes('bug') ||
-                     issueText.includes('fix') || issueText.includes('regression') ||
-                     issueText.includes('coverage'))) {
-                  assignedMember = member;
-                  triageReason = 'Issue relates to testing/quality work';
-                  break;
-                }
-                if ((role.includes('devops') || role.includes('infra') || role.includes('ops')) &&
-                    (issueText.includes('deploy') || issueText.includes('ci') ||
-                     issueText.includes('pipeline') || issueText.includes('docker') ||
-                     issueText.includes('infrastructure'))) {
-                  assignedMember = member;
-                  triageReason = 'Issue relates to DevOps/infrastructure work';
-                  break;
-                }
+              }
+
+              if (bestRoute) {
+                assignedMember = bestRoute.member;
+                triageReason = `Issue matches ${assignedMember.name}'s configured domain: ${bestRoute.matches.join(', ')}`;
               }
             }
 
@@ -200,20 +198,6 @@ jobs:
               issue_number: issue.number,
               labels: ['go:needs-research']
             });
-
-            // Auto-assign @copilot if enabled
-            if (isCopilot && copilotAutoAssign) {
-              try {
-                await github.rest.issues.addAssignees({
-                  owner: context.repo.owner,
-                  repo: context.repo.repo,
-                  issue_number: issue.number,
-                  assignees: ['copilot']
-                });
-              } catch (err) {
-                core.warning(`Could not auto-assign @copilot: ${err.message}`);
-              }
-            }
 
             // Build copilot evaluation note
             let copilotNote = '';
@@ -251,4 +235,33 @@ jobs:
               body: comment
             });
 
+            core.setOutput('is_copilot', isCopilot ? 'true' : 'false');
             core.info(`Triaged issue #${issue.number} → ${assignedMember.name} (${assignLabel})`);
+
+      - name: Assign approved Copilot coding agent
+        if: steps.copilot_policy.outputs.enabled == 'true' && steps.triage_issue.outputs.is_copilot == 'true'
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b #v7
+        with:
+          github-token: ${{ secrets.COPILOT_ASSIGN_TOKEN }}
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = context.payload.issue.number;
+            const { data: repoData } = await github.rest.repos.get({ owner, repo });
+
+            await github.request('POST /repos/{owner}/{repo}/issues/{issue_number}/assignees', {
+              owner,
+              repo,
+              issue_number,
+              assignees: ['copilot-swe-agent[bot]'],
+              agent_assignment: {
+                target_repo: `${owner}/${repo}`,
+                base_branch: repoData.default_branch,
+                custom_instructions: 'Read .squad/team.md, .squad/routing.md, and the assigned charter before work.',
+                custom_agent: '',
+                model: ''
+              },
+              headers: {
+                'X-GitHub-Api-Version': '2022-11-28'
+              }
+            });

--- a/.github/workflows/sync-squad-labels.yml
+++ b/.github/workflows/sync-squad-labels.yml
@@ -2,6 +2,7 @@ name: Sync Squad Labels
 
 on:
   push:
+    branches: [main]
     paths:
       - '.squad/team.md'
       - '.ai-team/team.md'
@@ -20,6 +21,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 #v7
+        with:
+          ref: ${{ github.event.repository.default_branch }}
 
       - name: Parse roster and sync labels
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 #v9

--- a/.mcp.json
+++ b/.mcp.json
@@ -4,7 +4,7 @@
       "command": "npx",
       "args": [
         "-y",
-        "@bradygaster/squad-cli@0.13.0",
+        "@bradygaster/squad-cli@0.12.0",
         "state-mcp"
       ],
       "env": {},


### PR DESCRIPTION
## Why

The governance validation check failed because Ralph's heartbeat had mutation permissions and a labeled-issue trigger even though repository policy defines it as a read-only monitor. The same validation run also exposed pre-existing drift between active governance workflows and their reviewed templates.

## Approach

Restored Ralph to a read-only monitor with read-only permissions, synchronized the active triage, issue-assignment, and label-sync workflows with their reviewed `.squad/templates` copies, and restored the reviewed Squad state MCP package pin.

## Scope

Included:
- Read-only heartbeat trigger and permissions.
- Active/template governance workflow alignment.
- `@bradygaster/squad-cli@0.12.0` MCP pin.

Non-goals: no validator weakening, skipped checks, or application runtime changes.

## Tracking

N/A

## Evidence and validation

- `python scripts/validate_governance.py` - passed
- `git diff --check` - passed

## Privacy, security, accessibility, legal, environmental, and social review

This is a governance and least-privilege workflow correction. No customer data, application behavior, public claims, or legal terms changed. Security-sensitive workflow permissions were reduced where required by policy.

## Licensing and provenance

No new dependencies or third-party content. The MCP version is aligned with the repository's reviewed package inventory.

## Branch, deployment, and cleanup

Changes are on the short-lived branch `u/cyrusjamula/governance-validation-fix` and target protected `main`. No deployment is included. The exact head is commit `ab8127bd03a4a94d13e1247f74e1b901cc3fe402`.

## Approval

Pending Cyrus approval of the exact head SHA.